### PR TITLE
[WIP] Failing test for issue 105

### DIFF
--- a/tests/spec/regression/issue105.js
+++ b/tests/spec/regression/issue105.js
@@ -1,0 +1,55 @@
+define(["Filer"], function(Filer) {
+
+ describe('trailing slashes in path names, issue 105', function() {
+    beforeEach(function() {
+      this.db_name = mk_db_name();
+      this.fs = new Filer.FileSystem({
+        name: this.db_name,
+        flags: 'FORMAT'
+      });
+    });
+
+    afterEach(function() {
+      indexedDB.deleteDatabase(this.db_name);
+      delete this.fs;
+    });
+
+    it('should deal with trailing slashes properly, path == path/', function() {
+      var complete = false;
+      var _result1, _result2;
+      var fs = this.fs;
+
+      fs.mkdir('/tmp', function(err) {
+        if(err) throw err;
+
+        fs.mkdir('/tmp/foo', function(err) {
+          if(err) throw err;
+
+          // Without trailing slash
+          fs.readdir('/tmp', function(err, result1) {
+            if(err) throw err;
+            _result1 = result1;
+
+            // With trailing slash
+            fs.readdir('/tmp/', function(err, result2) {
+              if(err) throw err;
+              _result2 = result2;
+
+              complete = true;
+            });
+          });
+        });
+      });
+
+      waitsFor(function() {
+        return complete;
+      }, 'test to complete', DEFAULT_TIMEOUT);
+
+      runs(function() {
+        expect(_result1.length).toEqual(1);
+        expect(_result2[0]).toEqual('tmp');
+        expect(_result1).toEqual(_result2);
+      });
+    });
+  });
+});

--- a/tests/test-manifest.js
+++ b/tests/test-manifest.js
@@ -44,6 +44,9 @@ define([
 
   // Ported node.js tests (filenames match names in https://github.com/joyent/node/tree/master/test)
   "spec/node-js/simple/test-fs-mkdir",
-  "spec/node-js/simple/test-fs-null-bytes"
+  "spec/node-js/simple/test-fs-null-bytes",
+
+  // Regressions, Bugs
+  "spec/regression/issue105"
 
 ]);


### PR DESCRIPTION
This shows the fail case trying to deal with a trailing slash on a pathname.  We're doing what node.js does in the path module; however, the binding must strip it later on.  We could just not do this https://github.com/joyent/node/blob/master/lib/path.js#L366-L367
