### PR TITLE
Increase the test timeout threshold from 2s to 5s

### DIFF
--- a/tests/require-config.js
+++ b/tests/require-config.js
@@ -78,8 +78,9 @@ require.config(config);
 assert = chai.assert;
 expect = chai.expect;
 
-// We need to setup describe() support before loading tests
-mocha.setup("bdd");
+// We need to setup describe() support before loading tests.
+// Use a test timeout of 5s and a slow-test warning of 250ms
+mocha.setup("bdd").timeout(5000).slow(250);
 
 require(["tests/test-manifest"], function() {
   window.onload = function() {


### PR DESCRIPTION
Sometimes the tests can appear to fail, when in reality it's just the main thread lagging, db operations taking time, or other disk nonsense (gc, paging, ...) on the test machine.  Mocha defaults to timeout tests that take more than 2s.  This increases it to 5s, and warns about tests that take longer than 250ms.
