### PR TITLE
Issue #158 - Added test to ensure that watchers monitoring hardlinks are...

### DIFF
--- a/tests/spec/fs.watch.spec.js
+++ b/tests/spec/fs.watch.spec.js
@@ -38,6 +38,35 @@ define(["Filer", "util"], function(Filer, util) {
         if(error) throw error;
       });
     });
+
+    it('should get a change event when a file hardlink is being watched and the original file is changed', function(done) {
+      var fs = util.fs();
+
+      fs.writeFile('/myfile', 'data', function(error) {
+        if(error) throw error;
+
+        fs.link('/myfile', '/hardlink', function(error) {
+          if(error) throw error;
+
+          var watcher = fs.watch('/hardlink', function(event, filename) {
+            expect(event).to.equal('change');
+            expect(filename).to.equal('/hardlink');
+            watcher.close();
+            done();
+          });
+
+          fs.appendFile('/myfile', '...more data', function(error) {
+            if(error) throw error;
+
+            fs.readFile('/hardlink', 'utf8', function(error, data) {
+              if(error) throw error;
+
+              expect(data).to.equal('data...more data')
+            });
+          });
+        });
+      });
+    });
   });
 
 });


### PR DESCRIPTION
... notified when the original file is updated

I'm not quite sure what to do with this, so I decided to open a pull request anyway. I've created the test, and it works, but the behavior that it's testing does not. Hardlink watchers will time out when waiting for alerts to changes in the original file. Should I file this as a new bug? 
