### PR TITLE
Fix Issue #230

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -60,6 +60,12 @@ function standard_check_result_cb(callback) {
  * Coerce array-like data to Buffer so we can .copy(), etc.
  * Allow null, a Buffer, or an object that can be dealt with
  * by the Buffer constructor (e.g., Typed Array, Array, ...)
+ *
+ * WARNING: be very careful not to call this on parameters of
+ * API methods that pass storage (like read). You don't want to
+ * overwrite a buffer that a caller is holding a reference to,
+ * and expects to be filled via the read. If the caller passes
+ * in a non-Buffer, we should throw instead of coerce.
  */
 function ensureBuffer(maybeBuffer) {
   if(!maybeBuffer) {


### PR DESCRIPTION
This makes sure that all data coming out of a provider that _should_ be a `Buffer` is.  Well behaved providers will just have their data passed straight through, while providers that store `ArrayBuffer` or `Array` will get things coerced into a `Buffer` for free.  This should allow us to optimize providers that want to store `Buffers` more efficiently, but not penalize those that don't.

I tried to think of a way to test this, but since we already had 20+ tests failing, fixing them is the only thing necessary--also, since this is internal code, I can't easily test it except through the public fs api.
