### PR TITLE
Fix issue #235 - Allow recursive watches on root directory

### DIFF
--- a/src/fs-watcher.js
+++ b/src/fs-watcher.js
@@ -1,5 +1,5 @@
 var EventEmitter = require('../lib/eventemitter.js');
-var isNullPath = require('./path.js').isNull;
+var Path = require('./path.js');
 var Intercom = require('../lib/intercom.js');
 
 /**
@@ -26,11 +26,15 @@ function FSWatcher() {
       return;
     }
 
-    if(isNullPath(filename_)) {
+    if(Path.isNull(filename_)) {
       throw new Error('Path must be a string without null bytes.');
     }
+
     // TODO: get realpath for symlinks on filename...
-    filename = filename_;
+
+    // Filer's Path.normalize strips trailing slashes, which we use here.
+    // See https://github.com/js-platform/filer/issues/105
+    filename = Path.normalize(filename_);
 
     // Whether to watch beneath this path or not
     recursive = recursive_ === true;

--- a/tests/index.js
+++ b/tests/index.js
@@ -32,6 +32,7 @@ require("./spec/fs.utimes.spec");
 require("./spec/fs.xattr.spec");
 require("./spec/fs.stats.spec");
 require("./spec/path-resolution.spec");
+require("./spec/trailing-slashes.spec");
 require("./spec/times.spec");
 require("./spec/time-flags.spec");
 require("./spec/fs.watch.spec");

--- a/tests/spec/fs.watch.spec.js
+++ b/tests/spec/fs.watch.spec.js
@@ -26,7 +26,7 @@ describe('fs.watch', function() {
     });
   });
 
-  it('should get a change event when writing a file in a dir with recursive=true', function(done) {
+  it('should get a change event when writing a file beneath root dir with recursive=true', function(done) {
     var fs = util.fs();
 
     var watcher = fs.watch('/', { recursive: true }, function(event, filename) {
@@ -38,6 +38,31 @@ describe('fs.watch', function() {
 
     fs.writeFile('/myfile', 'data', function(error) {
       if(error) throw error;
+    });
+  });
+
+  it('should get a change event when writing a file in a dir with recursive=true', function(done) {
+    var fs = util.fs();
+
+    fs.mkdir('/foo', function(err) {
+      if(err) throw err;
+
+      var watcher = fs.watch('/foo', { recursive: true }, function(event, filename) {
+        expect(event).to.equal('change');
+        expect(filename).to.equal('/foo');
+        watcher.close();
+        done();
+      });
+
+      // This shouldn't produce a change event
+      fs.writeFile('/myfile-not-in-foo', 'data', function(error) {
+        if(error) throw error;
+      });
+
+      // This should
+      fs.writeFile('/foo/myfile', 'data', function(error) {
+        if(error) throw error;
+      });
     });
   });
 });

--- a/tests/spec/trailing-slashes.spec.js
+++ b/tests/spec/trailing-slashes.spec.js
@@ -1,0 +1,15 @@
+var Path = require('../..').Path;
+var expect = require('chai').expect;
+
+describe('Path.normalize and trailing slashes', function() {
+
+  it('should remove trailing slashes as expected', function() {
+    var strip = Path.normalize;
+
+    expect(strip('/')).to.equal('/');
+    expect(strip('/foo/')).to.equal('/foo');
+    expect(strip('/foo//')).to.equal('/foo');
+    expect(strip('/foo/bar/baz/')).to.equal('/foo/bar/baz');
+  });
+
+});


### PR DESCRIPTION
This fixes the special case of `/` as the watched path, and how we deal with trailing slashes in order to create a sub-path component.

I've also beefed up the tests a bit to reflect what we expect things to do.
