### PR TITLE
Use global vs. window for browserify resolution of global object

### DIFF
--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -38,7 +38,7 @@ var localStorage = (function(window) {
     };
   }
   return window.localStorage;
-}(this));
+}(global));
 
 function Intercom() {
   var self = this;
@@ -54,14 +54,14 @@ function Intercom() {
   };
 
   // If we're in node.js, skip event registration
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
+  if (typeof document === 'undefined') {
     return;
   }
 
   if (document.attachEvent) {
     document.attachEvent('onstorage', storageHandler);
   } else {
-    window.addEventListener('storage', storageHandler, false);
+    global.addEventListener('storage', storageHandler, false);
   }
 }
 
@@ -192,7 +192,7 @@ Intercom.prototype._localStorageChanged = function(event, field) {
 };
 
 Intercom.prototype._onStorageEvent = function(event) {
-  event = event || window.event;
+  event = event || global.event;
   var self = this;
 
   if (this._localStorageChanged(event, INDEX_EMIT)) {

--- a/tests/lib/websql.js
+++ b/tests/lib/websql.js
@@ -2,7 +2,7 @@ var Filer = require('../..');
 
 var needsCleanup = [];
 if(global.addEventListener) {
-  window.addEventListener('beforeunload', function() {
+  global.addEventListener('beforeunload', function() {
     needsCleanup.forEach(function(f) { f(); });
   });
 }


### PR DESCRIPTION
This fixes yet another bug in our shared watches code.  Because of the way that browserify works, when we want to access `window` we need to use `global` and not `this`.  In our setup for Intercom, we test for `this.localStorage` and it fails, so we shim localStorage, and kill shared watches.  This fixes it.

I've also made the same fix to one other spot in our tests that was doing the same thing.
