### PR TITLE
Fix typo in sh.wget, which is using fs.cwd instead of the shell instance

### DIFF
--- a/src/shell/shell.js
+++ b/src/shell/shell.js
@@ -446,8 +446,7 @@ Shell.prototype.wget = function(url, options, callback) {
   // properly encoded URL.
   // i.e. instead of "/foo?bar/" we would expect "/foo?bar%2F"
   var path = options.filename || url.split('/').pop();
-
-  path = Path.resolve(fs.cwd, path);
+  path = Path.resolve(this.cwd, path);
 
   function onerror() {
     callback(new Error('unable to get resource'));


### PR DESCRIPTION
I noticed this tonight while debugging something else.  It should be using the shell instance's `cwd` property, since the filesystem doesn't have one.
