### PR TITLE
Fix #266 - let FileSystem ctor figure out if an existing filesystem exists

### DIFF
--- a/src/providers/indexeddb.js
+++ b/src/providers/indexeddb.js
@@ -104,14 +104,9 @@ IndexedDB.prototype.open = function(callback) {
   var that = this;
 
   // Bail if we already have a db open
-  if( that.db ) {
-    callback(null, false);
-    return;
+  if(that.db) {
+    return callback();
   }
-
-  // Keep track of whether we're accessing this db for the first time
-  // and therefore needs to get formatted.
-  var firstAccess = false;
 
   // NOTE: we're not using versioned databases.
   var openRequest = indexedDB.open(that.name);
@@ -124,13 +119,11 @@ IndexedDB.prototype.open = function(callback) {
       db.deleteObjectStore(FILE_STORE_NAME);
     }
     db.createObjectStore(FILE_STORE_NAME);
-
-    firstAccess = true;
   };
 
   openRequest.onsuccess = function onsuccess(event) {
     that.db = event.target.result;
-    callback(null, firstAccess);
+    callback();
   };
   openRequest.onerror = function onerror(error) {
     callback(new Errors.EINVAL('IndexedDB cannot be accessed. If private browsing is enabled, disable it.'));

--- a/src/providers/memory.js
+++ b/src/providers/memory.js
@@ -9,14 +9,10 @@ var asyncCallback = require('../../lib/async.js').setImmediate;
 var createDB = (function() {
   var pool = {};
   return function getOrCreate(name) {
-    var firstAccess = !pool.hasOwnProperty(name);
-    if(firstAccess) {
+    if(!pool.hasOwnProperty(name)) {
       pool[name] = {};
     }
-    return {
-      firstAccess: firstAccess,
-      db: pool[name]
-    };
+    return pool[name];
   };
 }());
 
@@ -81,11 +77,8 @@ Memory.isSupported = function() {
 };
 
 Memory.prototype.open = function(callback) {
-  var result = createDB(this.name);
-  this.db = result.db;
-  asyncCallback(function() {
-    callback(null, result.firstAccess);
-  });
+  this.db = createDB(this.name);
+  asyncCallback(callback);
 };
 Memory.prototype.getReadOnlyContext = function() {
   return new MemoryContext(this.db, true);

--- a/src/providers/websql.js
+++ b/src/providers/websql.js
@@ -130,8 +130,7 @@ WebSQL.prototype.open = function(callback) {
 
   // Bail if we already have a db open
   if(that.db) {
-    callback(null, false);
-    return;
+    return callback();
   }
 
   var db = global.openDatabase(that.name, WSQL_VERSION, WSQL_DESC, WSQL_SIZE);
@@ -148,18 +147,7 @@ WebSQL.prototype.open = function(callback) {
   }
   function onSuccess(transaction, result) {
     that.db = db;
-
-    function gotCount(transaction, result) {
-      var firstAccess = result.rows.item(0).count === 0;
-      callback(null, firstAccess);
-    }
-    function onError(transaction, error) {
-      callback(error);
-    }
-    // Keep track of whether we're accessing this db for the first time
-    // and therefore needs to get formatted.
-    transaction.executeSql("SELECT COUNT(id) AS count FROM " + FILE_STORE_NAME + ";",
-                           [], gotCount, onError);
+    callback();
   }
 
   // Create the table and index we'll need to store the fs data.

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,6 +7,7 @@
 require("./spec/filer.spec");
 
 // Filer.FileSystem.*
+require("./spec/filer.filesystem.spec");
 require("./spec/fs.spec");
 require("./spec/fs.stat.spec");
 require("./spec/fs.lstat.spec");

--- a/tests/spec/filer.filesystem.spec.js
+++ b/tests/spec/filer.filesystem.spec.js
@@ -1,0 +1,46 @@
+var Filer = require('../..');
+var util = require('../lib/test-utils.js');
+var expect = require('chai').expect;
+
+describe("Filer.FileSystem", function() {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should properly mount new or existing filesystem', function(done) {
+    var provider = util.provider().provider;
+
+    // 1) Should be able to open a new filesystem, and get empty root
+    var fs1 = new Filer.FileSystem({provider: provider}, function() {
+      fs1.readdir('/', function(err, entries) {
+        expect(err).not.to.exist;
+        expect(entries).to.be.an('array');
+        expect(entries.length).to.equal(0);
+
+        fs1.writeFile('/file', 'data', function(err) {
+          if(err) throw err;
+
+          // 2) Should be able to open an existing filesystem
+          var fs2 = new Filer.FileSystem({provider: provider}, function() {
+            fs2.readdir('/', function(err, entries) {
+              expect(err).not.to.exist;
+              expect(entries).to.be.an('array');
+              expect(entries.length).to.equal(1);
+              expect(entries[0]).to.equal('file');
+
+
+              // 3) FORMAT flag should wipe an existing filesystem
+              var fs3 = new Filer.FileSystem({provider: provider, flags: ['FORMAT']}, function() {
+                fs3.readdir('/', function(err, entries) {
+                  expect(err).not.to.exist;
+                  expect(entries).to.be.an('array');
+                  expect(entries.length).to.equal(0);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/spec/providers/providers.base.js
+++ b/tests/spec/providers/providers.base.js
@@ -35,10 +35,9 @@ module.exports = function createProviderTestsFor(providerName, testProvider) {
       expect(provider.getReadWriteContext).to.be.a('function');
     });
 
-    it("should open a new IndexedDB database", function(done) {
-      provider.open(function(error, firstAccess) {
+    it("should open a new provider database", function(done) {
+      provider.open(function(error) {
         expect(error).not.to.exist;
-        expect(firstAccess).to.be.true;
         done();
       });
     });


### PR DESCRIPTION
This leverages the change we made to `ensure_root_directory` to either use or create a root dir.  This change greatly simplifies the work a provider has to do to `open()`.
