### PR TITLE
async slimming

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -11,6 +11,7 @@
 
     // async.js functions used in Filer
 
+    //// nextTick implementation with browser-compatible fallback ////
     if (typeof process === 'undefined' || !(process.nextTick)) {
         if (typeof setImmediate === 'function') {
             async.nextTick = function (fn) {


### PR DESCRIPTION
we're only using setImmediate and eachSeries, so I reduced async.js to only include those two functions - grunt test shows all tests passing, so that looks like a winner.
