### PR TITLE
Fix #184 - remove unneeded standard_check_result_cb

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -40,24 +40,6 @@ var Stats = require('../stats.js');
 var Buffer = require('../buffer.js');
 
 /**
- * Many functions below use this callback pattern. If it's not
- * re-defined, we use this to generate a callback. NOTE: this
- * can be use for callbacks of both forms without problem (i.e.,
- * since result will be undefined if not returned):
- *  - callback(error)
- *  - callback(error, result)
- */
-function standard_check_result_cb(callback) {
-  return function(error, result) {
-    if(error) {
-      callback(error);
-    } else {
-      callback(null, result);
-    }
-  };
-}
-
-/**
  * Update node times. Only passed times are modified (undefined times are ignored)
  * and filesystem flags are examined in order to override update logic.
  */
@@ -862,11 +844,11 @@ function read_data(context, ofd, buffer, offset, length, position, callback) {
 function stat_file(context, path, callback) {
   path = normalize(path);
   var name = basename(path);
-  find_node(context, path, standard_check_result_cb(callback));
+  find_node(context, path, callback);
 }
 
 function fstat_file(context, ofd, callback) {
-  context.getObject(ofd.id, standard_check_result_cb(callback));
+  context.getObject(ofd.id, callback);
 }
 
 function lstat_file(context, path, callback) {
@@ -878,7 +860,7 @@ function lstat_file(context, path, callback) {
   var directoryData;
 
   if(ROOT_DIRECTORY_NAME == name) {
-    find_node(context, path, standard_check_result_cb(callback));
+    find_node(context, path, callback);
   } else {
     find_node(context, parentPath, read_directory_data);
   }
@@ -900,7 +882,7 @@ function lstat_file(context, path, callback) {
       if(!_(directoryData).has(name)) {
         callback(new Errors.ENOENT('a component of the path does not name an existing file', path));
       } else {
-        context.getObject(directoryData[name].id, standard_check_result_cb(callback));
+        context.getObject(directoryData[name].id, callback);
       }
     }
   }
@@ -1625,12 +1607,12 @@ function mkdir(fs, context, path, mode, callback) {
   // NOTE: we support passing a mode arg, but we ignore it internally for now.
   callback = arguments[arguments.length - 1];
   if(!pathCheck(path, callback)) return;
-  make_directory(context, path, standard_check_result_cb(callback));
+  make_directory(context, path, callback);
 }
 
 function rmdir(fs, context, path, callback) {
   if(!pathCheck(path, callback)) return;
-  remove_directory(context, path, standard_check_result_cb(callback));
+  remove_directory(context, path, callback);
 }
 
 function stat(fs, context, path, callback) {
@@ -1669,12 +1651,12 @@ function fstat(fs, context, fd, callback) {
 function link(fs, context, oldpath, newpath, callback) {
   if(!pathCheck(oldpath, callback)) return;
   if(!pathCheck(newpath, callback)) return;
-  link_node(context, oldpath, newpath, standard_check_result_cb(callback));
+  link_node(context, oldpath, newpath, callback);
 }
 
 function unlink(fs, context, path, callback) {
   if(!pathCheck(path, callback)) return;
-  unlink_node(context, path, standard_check_result_cb(callback));
+  unlink_node(context, path, callback);
 }
 
 function read(fs, context, fd, buffer, offset, length, position, callback) {
@@ -1694,7 +1676,7 @@ function read(fs, context, fd, buffer, offset, length, position, callback) {
   } else if(!_(ofd.flags).contains(O_READ)) {
     callback(new Errors.EBADF('descriptor does not permit reading'));
   } else {
-    read_data(context, ofd, buffer, offset, length, position, standard_check_result_cb(wrapped_cb));
+    read_data(context, ofd, buffer, offset, length, position, wrapped_cb);
   }
 }
 
@@ -1769,7 +1751,7 @@ function write(fs, context, fd, buffer, offset, length, position, callback) {
   } else if(buffer.length - offset < length) {
     callback(new Errors.EIO('intput buffer is too small'));
   } else {
-    write_data(context, ofd, buffer, offset, length, position, standard_check_result_cb(callback));
+    write_data(context, ofd, buffer, offset, length, position, callback);
   }
 }
 
@@ -1856,7 +1838,7 @@ function exists(fs, context, path, callback) {
 
 function getxattr(fs, context, path, name, callback) {
   if (!pathCheck(path, callback)) return;
-  getxattr_file(context, path, name, standard_check_result_cb(callback));
+  getxattr_file(context, path, name, callback);
 }
 
 function fgetxattr(fs, context, fd, name, callback) {
@@ -1865,7 +1847,7 @@ function fgetxattr(fs, context, fd, name, callback) {
     callback(new Errors.EBADF());
   }
   else {
-    fgetxattr_file(context, ofd, name, standard_check_result_cb(callback));
+    fgetxattr_file(context, ofd, name, callback);
   }
 }
 
@@ -1876,7 +1858,7 @@ function setxattr(fs, context, path, name, value, flag, callback) {
   }
 
   if (!pathCheck(path, callback)) return;
-  setxattr_file(context, path, name, value, flag, standard_check_result_cb(callback));
+  setxattr_file(context, path, name, value, flag, callback);
 }
 
 function fsetxattr(fs, context, fd, name, value, flag, callback) {
@@ -1893,13 +1875,13 @@ function fsetxattr(fs, context, fd, name, value, flag, callback) {
     callback(new Errors.EBADF('descriptor does not permit writing'));
   }
   else {
-    fsetxattr_file(context, ofd, name, value, flag, standard_check_result_cb(callback));
+    fsetxattr_file(context, ofd, name, value, flag, callback);
   }
 }
 
 function removexattr(fs, context, path, name, callback) {
   if (!pathCheck(path, callback)) return;
-  removexattr_file(context, path, name, standard_check_result_cb(callback));
+  removexattr_file(context, path, name, callback);
 }
 
 function fremovexattr(fs, context, fd, name, callback) {
@@ -1911,7 +1893,7 @@ function fremovexattr(fs, context, fd, name, callback) {
     callback(new Errors.EBADF('descriptor does not permit writing'));
   }
   else {
-    fremovexattr_file(context, ofd, name, standard_check_result_cb(callback));
+    fremovexattr_file(context, ofd, name, callback);
   }
 }
 
@@ -1957,7 +1939,7 @@ function lseek(fs, context, fd, offset, whence, callback) {
 
 function readdir(fs, context, path, callback) {
   if(!pathCheck(path, callback)) return;
-  read_directory(context, path, standard_check_result_cb(callback));
+  read_directory(context, path, callback);
 }
 
 function utimes(fs, context, path, atime, mtime, callback) {
@@ -1967,7 +1949,7 @@ function utimes(fs, context, path, atime, mtime, callback) {
   atime = (atime) ? atime : currentTime;
   mtime = (mtime) ? mtime : currentTime;
 
-  utimes_file(context, path, atime, mtime, standard_check_result_cb(callback));
+  utimes_file(context, path, atime, mtime, callback);
 }
 
 function futimes(fs, context, fd, atime, mtime, callback) {
@@ -1981,7 +1963,7 @@ function futimes(fs, context, fd, atime, mtime, callback) {
   } else if(!_(ofd.flags).contains(O_WRITE)) {
     callback(new Errors.EBADF('descriptor does not permit writing'));
   } else {
-    futimes_file(context, ofd, atime, mtime, standard_check_result_cb(callback));
+    futimes_file(context, ofd, atime, mtime, callback);
   }
 }
 
@@ -1993,7 +1975,7 @@ function rename(fs, context, oldpath, newpath, callback) {
     if(error) {
       callback(error);
     } else {
-      unlink_node(context, oldpath, standard_check_result_cb(callback));
+      unlink_node(context, oldpath, callback);
     }
   }
 
@@ -2005,12 +1987,12 @@ function symlink(fs, context, srcpath, dstpath, type, callback) {
   callback = arguments[arguments.length - 1];
   if(!pathCheck(srcpath, callback)) return;
   if(!pathCheck(dstpath, callback)) return;
-  make_symbolic_link(context, srcpath, dstpath, standard_check_result_cb(callback));
+  make_symbolic_link(context, srcpath, dstpath, callback);
 }
 
 function readlink(fs, context, path, callback) {
   if(!pathCheck(path, callback)) return;
-  read_link(context, path, standard_check_result_cb(callback));
+  read_link(context, path, callback);
 }
 
 function lstat(fs, context, path, callback) {
@@ -2034,7 +2016,7 @@ function truncate(fs, context, path, length, callback) {
   length = length || 0;
 
   if(!pathCheck(path, callback)) return;
-  truncate_file(context, path, length, standard_check_result_cb(callback));
+  truncate_file(context, path, length, callback);
 }
 
 function ftruncate(fs, context, fd, length, callback) {
@@ -2048,7 +2030,7 @@ function ftruncate(fs, context, fd, length, callback) {
   } else if(!_(ofd.flags).contains(O_WRITE)) {
     callback(new Errors.EBADF('descriptor does not permit writing'));
   } else {
-    ftruncate_file(context, ofd, length, standard_check_result_cb(callback));
+    ftruncate_file(context, ofd, length, callback);
   }
 }
 


### PR DESCRIPTION
I thought this had been done before, but I guess I was wrong.  This is just adding an extra fn-call overhead to all our callbacks, and does nothing.
