### PR TITLE
Fix #208 - Prevent grunt publish from destroying the gh-pages branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "chai": "~1.9.1",
     "grunt": "~0.4.0",
+    "grunt-banner": "^0.2.3",
     "grunt-browserify": "^2.1.0",
     "grunt-bump": "0.0.13",
     "grunt-contrib-clean": "~0.4.0",
@@ -39,14 +40,14 @@
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.1.2",
     "grunt-contrib-watch": "~0.3.1",
-    "grunt-git": "0.3.1",
+    "grunt-git": "git://github.com/sedge/grunt-git.git#gitrm",
     "grunt-npm": "git://github.com/sedge/grunt-npm.git#branchcheck",
     "grunt-prompt": "^1.1.0",
     "grunt-shell": "~0.7.0",
     "habitat": "^1.1.0",
     "mocha": "~1.18.2",
-    "semver": "^2.3.0",
-    "requirejs": "^2.1.14"
+    "requirejs": "^2.1.14",
+    "semver": "^2.3.0"
   },
   "main": "./src/index.js"
 }


### PR DESCRIPTION
Getting the build process to keep `dist/filer-test.js` on `gh-pages` only without blowing away the branch was complicated by having to generate the file on a branch that didn't track it. As a result, here's what I had to do:
1. Apply a banner to the generated file in order to ensure it was unique per filer version (even when tests weren't changed or updated)
2. Add a number of other grunt tasks to stash the generated file on `develop`, and then pop and commit it on `gh-pages`.
3. Patch the `grunt-git` module to include a `gitrm` task. The followup issue to replace the reference to my branch with the latest official version of the module is here: #321
