### PR TITLE
fs.rename() should normalize paths before using, dir vs. dir/

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1976,6 +1976,9 @@ function rename(fs, context, oldpath, newpath, callback) {
   if(!pathCheck(oldpath, callback)) return;
   if(!pathCheck(newpath, callback)) return;
 
+  oldpath = normalize(oldpath);
+  newpath = normalize(newpath);
+
   var oldParentPath = Path.dirname(oldpath);
   var newParentPath = Path.dirname(oldpath);
   var oldName = Path.basename(oldpath);

--- a/tests/bugs/rename-dir-trailing-slash.js
+++ b/tests/bugs/rename-dir-trailing-slash.js
@@ -1,0 +1,28 @@
+var Filer = require('../..');
+var util = require('../lib/test-utils.js');
+var expect = require('chai').expect;
+
+describe('trailing slashes in path names to work when renaming a dir', function() {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should deal with trailing slashes in rename, dir == dir/', function(done) {
+    var fs = util.fs();
+
+    fs.mkdir('/tmp', function(err) {
+      if(err) throw err;
+
+      fs.rename('/tmp/', '/new-tmp/', function(err) {
+        if(err) throw err;
+
+        fs.stat('/new-tmp', function(err, stats) {
+          if(err) throw err;
+          expect(stats).to.exist;
+          expect(stats.isDirectory()).to.be.true;
+
+          done();
+        });
+      });
+    });
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -75,3 +75,4 @@ require("./bugs/issue254.js");
 require("./bugs/issue258.js");
 require("./bugs/issue267.js");
 require("./bugs/issue270.js");
+require("./bugs/rename-dir-trailing-slash.js");


### PR DESCRIPTION
We hit a bug in Brackets where renames are using dir paths like this: `fs.rename("/old-path/", "/new-path/", ...)` and Filer is using the trailing slash as part of the path.  We fixed something like this in issue #105 but seem to have missed the rename case.