### PR TITLE
Stop Safari from prompting user to allow 5M of storage for WebSQL

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -16,7 +16,6 @@ module.exports = {
   IDB_RW: 'readwrite',
 
   WSQL_VERSION: "1",
-  WSQL_SIZE: 5 * 1024 * 1024,
   WSQL_DESC: "FileSystem Storage",
 
   MODE_FILE: 'FILE',

--- a/src/providers/websql.js
+++ b/src/providers/websql.js
@@ -1,7 +1,6 @@
 var FILE_SYSTEM_NAME = require('../constants.js').FILE_SYSTEM_NAME;
 var FILE_STORE_NAME = require('../constants.js').FILE_STORE_NAME;
 var WSQL_VERSION = require('../constants.js').WSQL_VERSION;
-var WSQL_SIZE = require('../constants.js').WSQL_SIZE;
 var WSQL_DESC = require('../constants.js').WSQL_DESC;
 var Errors = require('../errors.js');
 var FilerBuffer = require('../buffer.js');
@@ -133,7 +132,16 @@ WebSQL.prototype.open = function(callback) {
     return callback();
   }
 
-  var db = global.openDatabase(that.name, WSQL_VERSION, WSQL_DESC, WSQL_SIZE);
+  // Deal with size limit like pouchdb:
+  // http://pouchdb.com/2014/10/26/10-things-i-learned-from-reading-and-writing-the-pouchdb-source.html
+  // https://github.com/pouchdb/pouchdb/blob/39da6013d74685189fcdf5bc2c617db5b76e88bd/lib/adapters/websql/utils.js#L161-L175
+  var isAndroid = false;
+  if(global.navigator && global.navigator.userAgent) {
+    isAndroid = /Android/.test(window.navigator.userAgent);
+  }
+  var dbSize = isAndroid ? 5000000 : 1; // in PhantomJS, if you use 0 it will crash
+
+  var db = global.openDatabase(that.name, WSQL_VERSION, WSQL_DESC, dbSize);
   if(!db) {
     callback("[WebSQL] Unable to open database.");
     return;


### PR DESCRIPTION
In Bramble, using the Fallback provider with Safari, I'm being prompted to allow 5M of storage.  This is due to us asking for more than 5M as defined by Apple.  Reducing the number (and following what pouchdb does) fixes this.

r? @gideonthomas 
