### PR TITLE
Fixed #360 - Added newly exposed internal modules to release commits

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -171,7 +171,16 @@ module.exports = function(grunt) {
         files: ['package.json', 'bower.json'],
         commit: true,
         commitMessage: 'v%VERSION%',
-        commitFiles: ['package.json', 'bower.json', './dist/filer.js', './dist/filer.min.js'],
+        commitFiles: [
+          'package.json',
+          'bower.json',
+          './dist/filer.js',
+          './dist/filer.min.js',
+          './dist/buffer.js',
+          './dist/buffer.min.js',
+          './dist/path.js',
+          './dist/path.min.js'
+        ],
         createTag: true,
         tagName: 'v%VERSION%',
         tagMessage: 'v%VERSION%',


### PR DESCRIPTION
The problem was build artifacts persisting when the grunt task switched to the `gh-pages` branch. These artifacts ended up being files we forgot to add to the releases.