### PR TITLE
Fix #393: add test for truncate with length undefined

### DIFF
--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -127,6 +127,37 @@ describe('fs.truncate', function() {
     });
   });
 
+  it('should assume a length of 0 if passed undefined', function(done) {
+    var fs = util.fs();
+    var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    fs.open('/myfile', 'w', function(error, result) {
+      if(error) throw error;
+
+      var fd = result;
+      fs.write(fd, buffer, 0, buffer.length, 0, function(error, result) {
+        if(error) throw error;
+        expect(result).to.equal(buffer.length);
+
+        fs.close(fd, function(error) {
+          if(error) throw error;
+
+          // We want to use undefined to see that it defaults to 0
+          fs.truncate('/myfile', undefined, function(error) {
+            expect(error).not.to.exist;
+
+            fs.stat('/myfile', function(error, result) {
+              if(error) throw error;
+
+              expect(result.size).to.equal(0);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
   it('should truncate a valid descriptor', function(done) {
     var fs = util.fs();
     var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);


### PR DESCRIPTION
This pull request adds a new test for truncate to make sure that we use the correct default when `length === undefined`.