### PR TITLE
Fix issue #398 - Add testing for promises to all test cases in fs.writeFile-readFile.spec.js file

### DIFF
--- a/tests/spec/fs.writeFile-readFile.spec.js
+++ b/tests/spec/fs.writeFile-readFile.spec.js
@@ -124,6 +124,7 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
     p.then(() => {
       expect(fsPromises.readFile('/myfile', 'utf8')).to.be.a('Promise');
     });
+    return p;
   });
 
   it('should error when path is wrong to readFile', function() {
@@ -136,72 +137,52 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
       });
   });
 
-  it('should write, read a utf8 file without specifying utf8 in writeFile', function(done) {
+  it('should write, read a utf8 file without specifying utf8 in writeFile', function() {
     var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fsPromises.writeFile('/myfile', contents)
+    return fsPromises.writeFile('/myfile', contents)
       .then( () => fsPromises.readFile('/myfile', 'utf8'))
-      .then(data => { 
-        expect(data).to.equal(contents);
-        done(); 
-      })
-      .catch(error => { throw error; });
+      .then(data => { expect(data).to.equal(contents); });
   });
 
-  it('should write, read a utf8 file with "utf8" option to writeFile', function(done) {
+  it('should write, read a utf8 file with "utf8" option to writeFile', function() {
     var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fsPromises.writeFile('/myfile', contents, 'utf8') 
+    return fsPromises.writeFile('/myfile', contents, 'utf8') 
       .then( () => fsPromises.readFile('/myfile', 'utf8'))
-      .then(data => { 
-        expect(data).to.equal(contents); 
-        done(); 
-      })  
-      .catch(error => { throw error; });
+      .then(data => { expect(data).to.equal(contents); });
   });
 
-  it('should write, read a utf8 file with {encoding: "utf8"} option to writeFile', function(done) {
+  it('should write, read a utf8 file with {encoding: "utf8"} option to writeFile', function() {
     var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fsPromises.writeFile('/myfile', contents, { encoding: 'utf8' })
+    return fsPromises.writeFile('/myfile', contents, { encoding: 'utf8' })
       .then( () => fsPromises.readFile('/myfile', 'utf8'))
-      .then(data => { 
-        expect(data).to.equal(contents);
-        done(); 
-      }) 
-      .catch(error => { throw error; });
+      .then(data => { expect(data).to.equal(contents); });
   });
 
-  it('should write, read a binary file', function(done) {
+  it('should write, read a binary file', function() {
     var fsPromises = util.fs().promises;
     // String and utf8 binary encoded versions of the same thing: 'This is a file.'
     var binary = new Buffer([84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 102, 105, 108, 101, 46]);
 
-    fsPromises.writeFile('/myfile', binary)
+    return fsPromises.writeFile('/myfile', binary)
       .then( () => fsPromises.readFile('/myfile'))
-      .then(data => { 
-        expect(data).to.deep.equal(binary); 
-        done(); 
-      }) 
-      .catch(error => { throw error; });
+      .then(data => { expect(data).to.deep.equal(binary); });
   });
 
-  it('should follow symbolic links', function(done) {
+  it('should follow symbolic links', function() {
     var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fsPromises.writeFile('/myfile', '', { encoding: 'utf8' })
+    return fsPromises.writeFile('/myfile', '', { encoding: 'utf8' })
       .then( () => fsPromises.symlink('/myfile', '/myFileLink'))
       .then( () => fsPromises.writeFile('/myFileLink', contents, 'utf8'))
       .then( () => fsPromises.readFile('/myFileLink', 'utf8'))
-      .then(data => { 
-        expect(data).to.equal(contents); 
-        done(); 
-      }) 
-      .catch(error => { throw error; });
+      .then(data => { expect(data).to.equal(contents); });
   });
 });
 

--- a/tests/spec/fs.writeFile-readFile.spec.js
+++ b/tests/spec/fs.writeFile-readFile.spec.js
@@ -99,3 +99,118 @@ describe('fs.writeFile, fs.readFile', function() {
     });
   });
 });
+
+
+
+
+
+describe('fs.promises.writeFile, fs.promises.readFile', function() {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should be a function', function() {
+    var fs = util.fs();
+    expect(fs.promises.writeFile).to.be.a('function');
+    expect(fs.promises.readFile).to.be.a('function');
+  });
+
+  it('should return a promise', function() {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+
+    expect(fs.promises.writeFile('/myfile', contents)).to.be.a('Promise');
+    expect(fs.promises.readFile('/myfile', 'utf8')).to.be.a('Promise');
+  });
+
+  it('should error when path is wrong to readFile', function(done) {
+    var fs = util.fs();
+
+    
+    fs.promises.readFile('/no-such-file', 'utf8')
+      .then(data => expect(data).not.to.exist)
+      .catch(error => { expect(error).to.exist; expect(error.code).to.equal('ENOENT'); done(); });
+    
+
+  });
+
+  it('should write, read a utf8 file without specifying utf8 in writeFile', function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+
+    fs.promises.writeFile('/myfile', contents)
+      .then( () => {
+
+        fs.promises.readFile('/myfile', 'utf8')
+          .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
+
+      })
+      .catch(error => { throw error; });
+  });
+
+  it('should write, read a utf8 file with "utf8" option to writeFile', function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+
+    fs.promises.writeFile('/myfile', contents, 'utf8') 
+      .then( () => {
+
+        fs.promises.readFile('/myfile', 'utf8')
+          .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
+
+      })  
+      .catch(error => { throw error; });
+  });
+
+  it('should write, read a utf8 file with {encoding: "utf8"} option to writeFile', function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+
+    fs.promises.writeFile('/myfile', contents, { encoding: 'utf8' })
+      .then( () => {
+
+        fs.promises.readFile('/myfile', 'utf8')
+          .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
+
+      }) 
+      .catch(error => { throw error; });
+  });
+
+  it('should write, read a binary file', function(done) {
+    var fs = util.fs();
+    // String and utf8 binary encoded versions of the same thing: 'This is a file.'
+    var binary = new Buffer([84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 102, 105, 108, 101, 46]);
+
+    fs.promises.writeFile('/myfile', binary)
+      .then( () => {
+
+        fs.promises.readFile('/myfile')
+          .then( (data, error) => { expect(data).to.deep.equal(binary); expect(error).not.to.exist; done(); });
+
+      }) 
+      .catch(error => { throw error; });
+  });
+
+  it('should follow symbolic links', function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+
+    fs.promises.writeFile('/myfile', '', { encoding: 'utf8' })
+      .then( () => {
+        fs.promises.symlink('/myfile', '/myFileLink')
+          .then( () => {
+            fs.promises.writeFile('/myFileLink', contents, 'utf8')
+              .then( () => {
+
+                fs.promises.readFile('/myFileLink', 'utf8')
+                  .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
+                  
+              }) 
+              .catch(error => { throw error; });   
+          }) 
+          .catch(error => { throw error; });
+      }) 
+      .catch(error => { throw error; });
+  });
+});
+
+

--- a/tests/spec/fs.writeFile-readFile.spec.js
+++ b/tests/spec/fs.writeFile-readFile.spec.js
@@ -100,114 +100,128 @@ describe('fs.writeFile, fs.readFile', function() {
   });
 });
 
+/**
+ * fsPromises tests
+ */
 
-
-
-
-describe('fs.promises.writeFile, fs.promises.readFile', function() {
+describe('fsPromises.writeFile, fsPromises.readFile', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
   it('should be a function', function() {
-    var fs = util.fs();
-    expect(fs.promises.writeFile).to.be.a('function');
-    expect(fs.promises.readFile).to.be.a('function');
+    var fsPromises = util.fs().promises;
+    expect(fsPromises.writeFile).to.be.a('function');
+    expect(fsPromises.readFile).to.be.a('function');
   });
 
   it('should return a promise', function() {
-    var fs = util.fs();
+    var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    expect(fs.promises.writeFile('/myfile', contents)).to.be.a('Promise');
-    expect(fs.promises.readFile('/myfile', 'utf8')).to.be.a('Promise');
+    expect(fsPromises.writeFile('/myfile', contents)).to.be.a('Promise');
+    expect(fsPromises.readFile('/myfile', 'utf8')).to.be.a('Promise');
   });
 
   it('should error when path is wrong to readFile', function(done) {
-    var fs = util.fs();
+    var fsPromises = util.fs().promises;
 
-    
-    fs.promises.readFile('/no-such-file', 'utf8')
+    fsPromises.readFile('/no-such-file', 'utf8')
       .then(data => expect(data).not.to.exist)
-      .catch(error => { expect(error).to.exist; expect(error.code).to.equal('ENOENT'); done(); });
-    
-
+      .catch(error => { 
+        expect(error).to.exist; 
+        expect(error.code).to.equal('ENOENT'); 
+        done(); 
+      });
   });
 
   it('should write, read a utf8 file without specifying utf8 in writeFile', function(done) {
-    var fs = util.fs();
+    var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fs.promises.writeFile('/myfile', contents)
+    fsPromises.writeFile('/myfile', contents)
       .then( () => {
 
-        fs.promises.readFile('/myfile', 'utf8')
-          .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
-
+        fsPromises.readFile('/myfile', 'utf8')
+          .then(data => { 
+            expect(data).to.equal(contents);
+            done(); 
+          })
+          .catch(error => expect(error).not.to.exist);
       })
       .catch(error => { throw error; });
   });
 
   it('should write, read a utf8 file with "utf8" option to writeFile', function(done) {
-    var fs = util.fs();
+    var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fs.promises.writeFile('/myfile', contents, 'utf8') 
+    fsPromises.writeFile('/myfile', contents, 'utf8') 
       .then( () => {
 
-        fs.promises.readFile('/myfile', 'utf8')
-          .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
-
+        fsPromises.readFile('/myfile', 'utf8')
+          .then(data => { 
+            expect(data).to.equal(contents); 
+            done(); 
+          })
+          .catch(error => expect(error).not.to.exist);
       })  
       .catch(error => { throw error; });
   });
 
   it('should write, read a utf8 file with {encoding: "utf8"} option to writeFile', function(done) {
-    var fs = util.fs();
+    var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fs.promises.writeFile('/myfile', contents, { encoding: 'utf8' })
+    fsPromises.writeFile('/myfile', contents, { encoding: 'utf8' })
       .then( () => {
 
-        fs.promises.readFile('/myfile', 'utf8')
-          .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
-
+        fsPromises.readFile('/myfile', 'utf8')
+          .then(data => { 
+            expect(data).to.equal(contents);
+            done(); 
+          })
+          .catch(error => expect(error).not.to.exist);
       }) 
       .catch(error => { throw error; });
   });
 
   it('should write, read a binary file', function(done) {
-    var fs = util.fs();
+    var fsPromises = util.fs().promises;
     // String and utf8 binary encoded versions of the same thing: 'This is a file.'
     var binary = new Buffer([84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 102, 105, 108, 101, 46]);
 
-    fs.promises.writeFile('/myfile', binary)
+    fsPromises.writeFile('/myfile', binary)
       .then( () => {
 
-        fs.promises.readFile('/myfile')
-          .then( (data, error) => { expect(data).to.deep.equal(binary); expect(error).not.to.exist; done(); });
-
+        fsPromises.readFile('/myfile')
+          .then(data => { 
+            expect(data).to.deep.equal(binary); 
+            done(); 
+          })
+          .catch(error => expect(error).not.to.exist);
       }) 
       .catch(error => { throw error; });
   });
 
   it('should follow symbolic links', function(done) {
-    var fs = util.fs();
+    var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    fs.promises.writeFile('/myfile', '', { encoding: 'utf8' })
+    fsPromises.writeFile('/myfile', '', { encoding: 'utf8' })
       .then( () => {
-        fs.promises.symlink('/myfile', '/myFileLink')
+        fsPromises.symlink('/myfile', '/myFileLink')
           .then( () => {
-            fs.promises.writeFile('/myFileLink', contents, 'utf8')
+            fsPromises.writeFile('/myFileLink', contents, 'utf8')
               .then( () => {
 
-                fs.promises.readFile('/myFileLink', 'utf8')
-                  .then( (data, error) => { expect(data).to.equal(contents); expect(error).not.to.exist; done(); });
-                  
-              }) 
-              .catch(error => { throw error; });   
-          }) 
-          .catch(error => { throw error; });
+                fsPromises.readFile('/myFileLink', 'utf8')
+                  .then(data => { 
+                    expect(data).to.equal(contents); 
+                    done(); 
+                  })
+                  .catch(error => expect(error).not.to.exist); 
+              });  
+          });
       }) 
       .catch(error => { throw error; });
   });

--- a/tests/spec/fs.writeFile-readFile.spec.js
+++ b/tests/spec/fs.writeFile-readFile.spec.js
@@ -118,19 +118,21 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
     var fsPromises = util.fs().promises;
     var contents = 'This is a file.';
 
-    expect(fsPromises.writeFile('/myfile', contents)).to.be.a('Promise');
-    expect(fsPromises.readFile('/myfile', 'utf8')).to.be.a('Promise');
+    var p = fsPromises.writeFile('/myfile', contents);
+    expect(p).to.be.a('Promise');
+
+    p.then(() => {
+      expect(fsPromises.readFile('/myfile', 'utf8')).to.be.a('Promise');
+    });
   });
 
-  it('should error when path is wrong to readFile', function(done) {
+  it('should error when path is wrong to readFile', function() {
     var fsPromises = util.fs().promises;
 
-    fsPromises.readFile('/no-such-file', 'utf8')
-      .then(data => expect(data).not.to.exist)
+    return fsPromises.readFile('/no-such-file', 'utf8')
       .catch(error => { 
         expect(error).to.exist; 
         expect(error.code).to.equal('ENOENT'); 
-        done(); 
       });
   });
 
@@ -139,14 +141,10 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
     var contents = 'This is a file.';
 
     fsPromises.writeFile('/myfile', contents)
-      .then( () => {
-
-        fsPromises.readFile('/myfile', 'utf8')
-          .then(data => { 
-            expect(data).to.equal(contents);
-            done(); 
-          })
-          .catch(error => expect(error).not.to.exist);
+      .then( () => fsPromises.readFile('/myfile', 'utf8'))
+      .then(data => { 
+        expect(data).to.equal(contents);
+        done(); 
       })
       .catch(error => { throw error; });
   });
@@ -156,14 +154,10 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
     var contents = 'This is a file.';
 
     fsPromises.writeFile('/myfile', contents, 'utf8') 
-      .then( () => {
-
-        fsPromises.readFile('/myfile', 'utf8')
-          .then(data => { 
-            expect(data).to.equal(contents); 
-            done(); 
-          })
-          .catch(error => expect(error).not.to.exist);
+      .then( () => fsPromises.readFile('/myfile', 'utf8'))
+      .then(data => { 
+        expect(data).to.equal(contents); 
+        done(); 
       })  
       .catch(error => { throw error; });
   });
@@ -173,14 +167,10 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
     var contents = 'This is a file.';
 
     fsPromises.writeFile('/myfile', contents, { encoding: 'utf8' })
-      .then( () => {
-
-        fsPromises.readFile('/myfile', 'utf8')
-          .then(data => { 
-            expect(data).to.equal(contents);
-            done(); 
-          })
-          .catch(error => expect(error).not.to.exist);
+      .then( () => fsPromises.readFile('/myfile', 'utf8'))
+      .then(data => { 
+        expect(data).to.equal(contents);
+        done(); 
       }) 
       .catch(error => { throw error; });
   });
@@ -191,14 +181,10 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
     var binary = new Buffer([84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 102, 105, 108, 101, 46]);
 
     fsPromises.writeFile('/myfile', binary)
-      .then( () => {
-
-        fsPromises.readFile('/myfile')
-          .then(data => { 
-            expect(data).to.deep.equal(binary); 
-            done(); 
-          })
-          .catch(error => expect(error).not.to.exist);
+      .then( () => fsPromises.readFile('/myfile'))
+      .then(data => { 
+        expect(data).to.deep.equal(binary); 
+        done(); 
       }) 
       .catch(error => { throw error; });
   });
@@ -208,20 +194,12 @@ describe('fsPromises.writeFile, fsPromises.readFile', function() {
     var contents = 'This is a file.';
 
     fsPromises.writeFile('/myfile', '', { encoding: 'utf8' })
-      .then( () => {
-        fsPromises.symlink('/myfile', '/myFileLink')
-          .then( () => {
-            fsPromises.writeFile('/myFileLink', contents, 'utf8')
-              .then( () => {
-
-                fsPromises.readFile('/myFileLink', 'utf8')
-                  .then(data => { 
-                    expect(data).to.equal(contents); 
-                    done(); 
-                  })
-                  .catch(error => expect(error).not.to.exist); 
-              });  
-          });
+      .then( () => fsPromises.symlink('/myfile', '/myFileLink'))
+      .then( () => fsPromises.writeFile('/myFileLink', contents, 'utf8'))
+      .then( () => fsPromises.readFile('/myFileLink', 'utf8'))
+      .then(data => { 
+        expect(data).to.equal(contents); 
+        done(); 
       }) 
       .catch(error => { throw error; });
   });


### PR DESCRIPTION
I rewrote all test cases in the fs.writeFile-readFile.spec.js file to work with promises, testing that integration of promises into the readFile and writeFile methods works as expected.

In addition, I also check that fs.promises.readFile() and fs.promises.writeFile() methods return a promise as expected.

I added this code at the bottom of the file after the original test cases for readFile and writeFile methods.