### PR TITLE
Issue 396 - Add a test for fs.promises.stat() when the path does not exist

### DIFF
--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -112,4 +112,4 @@ describe('fsPromises.stat', function() {
       })
       .then(() => done())
   });
-})
+});

--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -101,15 +101,13 @@ describe('fsPromises.stat', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
-  it('should return an error if path does not exist', function(done) {
+  it('should return an error if path does not exist', function() {
     var fsPromises = util.fs().promises;
 
-    fsPromises.stat('/tmp')
-      .then(result => expect(result).not.to.exist)
+    return fsPromises.stat('/tmp')
       .catch(error => {
         expect(error).to.exist;
         expect(error.code).to.equal('ENOENT');
-      })
-      .then(() => done());
+      });
   });
 });

--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -92,3 +92,24 @@ describe('fs.stat', function() {
     });
   });
 });
+
+/**
+ * fsPromises tests
+ */
+
+describe('fsPromises.stat', function() {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should return an error if path does not exist', function(done) {
+    var fsPromises = util.fs().promises;
+
+    fsPromises.stat('/tmp')
+      .then(result => expect(result).not.to.exist)
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOENT');
+      })
+      .then(() => done())
+  });
+})

--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -110,6 +110,6 @@ describe('fsPromises.stat', function() {
         expect(error).to.exist;
         expect(error.code).to.equal('ENOENT');
       })
-      .then(() => done())
+      .then(() => done());
   });
 });


### PR DESCRIPTION
Fix #396 
<details><summary>Test log</summary>
<p>

```
START:
18 09 2018 20:47:16.270:INFO [karma]: Karma v3.0.0 server started at http://0.0.0.0:9876/
18 09 2018 20:47:16.272:INFO [launcher]: Launching browser ChromeHeadless with unlimited concurrency
18 09 2018 20:47:16.282:INFO [launcher]: Starting browser ChromeHeadless
18 09 2018 20:47:17.093:INFO [HeadlessChrome 0.0.0 (Windows 10 0.0.0)]: Connected on socket M2LWgwfiA9J7Fd8TAAAA with id 8357030
  fs.stat
    √ should follow symbolic links and return a stat object for the resulting path
    √ should return a stat object for a valid descriptor
  fsPromises.stat
    √ should return an error if path does not exist
  fs.lstat
    √ should be a function
    √ should return an error if path does not exist
    √ should return a stat object if path is not a symbolic link
    √ should return a stat object if path is a symbolic link
  fs.exists
    √ should be a function
WARN: 'This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback'
    √ should return false if path does not exist
WARN: 'This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback'
    √ should return true if path exists
WARN: 'This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback'
    √ should follow symbolic links and return true for the resulting path
  fs.mknod
    √ should be a function
    √ should return an error if part of the parent path does not exist
    √ should return an error if path already exists
    √ should return an error if the parent node is not a directory
    √ should return an error if the mode provided is not DIRECTORY or FILE
    √ should make a new directory
    √ should make a new file
  fs.mkdir
    √ should be a function
    √ should return an error if part of the parent path does not exist
    √ should return an error if the path already exists
    √ should make a new directory
  fs.readdir
    √ should be a function
    √ should return an error if the path does not exist
    √ should return a list of files from an existing directory
    √ should follow symbolic links
  fs.rmdir
    √ should be a function
    √ should return an error if the path does not exist
    √ should return an error if attempting to remove the root directory
    √ should return an error if the directory is not empty
    √ should return an error if the path is not a directory
    √ should return an error if the path is a symbolic link
    √ should remove an existing directory
  fs.open
    √ should be a function
    √ should return an error if the parent path does not exist
    √ should return an error when flagged for read and the path does not exist
    √ should return an error when flagged for write and the path is a directory
    √ should return an error when flagged for append and the path is a directory
    √ should return a unique file descriptor
    √ should return the argument value of the file descriptor index matching the value set by the first useable file descriptor constant
    √ should create a new file when flagged for write
    √ should error if an ofd's node goes away while open
  fs.write
    √ should be a function
    √ should write data to a file
    √ should update the current file position
  fs.writeFile, fs.readFile
    √ should be a function
    √ should error when path is wrong to readFile
    √ should write, read a utf8 file without specifying utf8 in writeFile
    √ should write, read a utf8 file with "utf8" option to writeFile
    √ should write, read a utf8 file with {encoding: "utf8"} option to writeFile
    √ should write, read a binary file
    √ should follow symbolic links
  fs.appendFile
    √ should be a function
    √ should append a utf8 file without specifying utf8 in appendFile
    √ should append a utf8 file with "utf8" option to appendFile
    √ should append a utf8 file with {encoding: "utf8"} option to appendFile
    √ should append a binary file
    √ should follow symbolic links
    √ should work when file does not exist, and create the file
  fs.read
    √ should be a function
    √ should read data from a file
    √ should update the current file position
    √ should fail to read a directory
  fs.close
    √ should be a function
    √ should release the file descriptor
  fs.link
    √ should be a function
    √ should create a link to an existing file
    √ should create hard link to identical data node
    √ should not follow symbolic links
    √ should not allow links to a directory
  fs.unlink
    √ should be a function
    √ should remove a link to an existing file
    √ should not follow symbolic links
    √ should not unlink directories
  fs.rename
    √ should be a function
    √ should rename an existing file
    √ should rename an existing directory
    √ should rename an existing directory if the new path points to an existing directory
    √ should fail to rename an existing directory if the new path points to an existing directory that is not empty
    √ should fail to rename an existing directory if the new path points to an existing file
  fs.lseek
    √ should be a function
    √ should not follow symbolic links
    √ should set the current position if whence is SET
    √ should update the current position if whence is CUR
    √ should update the current position if whence is END
  fs.symlink
    √ should be a function
    √ should return an error if part of the parent destination path does not exist
    √ should return an error if the destination path already exists
    √ should create a symlink
  fs.readlink
    √ should be a function
    √ should return an error if part of the parent destination path does not exist
    √ should return an error if the path is not a symbolic link
    √ should return the contents of a symbolic link
  fs.truncate
    √ should be a function
    √ should error when length is negative
    √ should error when path is not a file
    √ should truncate a file
    √ should pad a file with zeros when the length is greater than the file size
    √ should update the file size
    √ should truncate a valid descriptor
    √ should follow symbolic links
  fs.utimes
    √ should be a function
    √ should error when atime is negative
    √ should error when mtime is negative
    √ should error when atime is as invalid number
    √ should error when path does not exist
    √ should error when mtime is an invalid number
    √ should error when file descriptor is invalid
    √ should change atime and mtime of a file path
    √ should change atime and mtime for a valid file descriptor
    √ should update atime and mtime of directory path
    √ should update atime and mtime using current time if arguments are null
  fs.xattr
    √ should be a function
    √ should error when setting with a name that is not a string
    √ should error when setting with a name that is null
    √ should error when setting with an invalid flag
    √ should error when when setting an extended attribute which exists with XATTR_CREATE flag
    √ should error when setting an extended attribute which does not exist with XATTR_REPLACE flag
    √ should error when getting an attribute with a name that is empty
    √ should error when getting an attribute where the name is not a string
    √ should error when getting an attribute that does not exist
    √ should error when file descriptor is invalid
    √ should set and get an extended attribute of a path
    √ should error when attempting to remove a non-existing attribute
    √ should set and get an empty string as a value
    √ should set and get an extended attribute for a valid file descriptor
    √ should set and get an object to an extended attribute
    √ should update/overwrite an existing extended attribute
    √ should set multiple extended attributes for a path
    √ should remove an extended attribute from a path
    √ should remove an extended attribute from a valid file descriptor
    √ should allow setting with a null value
  fs.stats
    #isFile()
      √ should be a function
      √ should return true if stats are for file
      √ should return false if stats are for directory
      √ should return false if stats are for symbolic link
    #isDirectory()
      √ should be a function
      √ should return false if stats are for file
      √ should return true if stats are for directory
      √ should return false if stats are for symbolic link
    #isBlockDevice()
      √ should be a function
      √ should return false
    #isCharacterDevice()
      √ should be a function
      √ should return false
    #isSymbolicLink()
      √ should be a function
      √ should return false if stats are for file
      √ should return false if stats are for directory
      √ should return true if stats are for symbolic link
    #isFIFO()
      √ should be a function
      √ should return false
    #isSocket()
      √ should be a function
      √ should return false
    generated name property
      √ should correct return name for a file
      √ should correct return name for an fd
  path resolution
    √ should follow a symbolic link to the root directory
    √ should follow a symbolic link to a directory
    √ should follow a symbolic link to a file
    √ should follow multiple symbolic links to a file
    √ should error if symbolic link leads to itself
    √ should error if it follows more than 10 symbolic links
    √ should follow a symbolic link in the path to a file
    √ should error if a symbolic link in the path to a file is itself a file
    √ should properly add trailing slashes with Path.addTrailing()
    √ should properly remove trailing slashes with Path.removeTrailing()
  Path.normalize and trailing slashes
    √ should remove trailing slashes as expected
  node times (atime, mtime, ctime)
    √ should update ctime when calling fs.rename()
    √ should update ctime, mtime, atime when calling fs.truncate()
    √ should update ctime, mtime, atime when calling fs.ftruncate()
    √ should make no change when calling fs.stat()
    √ should make no change when calling fs.fstat()
    √ should make no change when calling fs.lstat()
WARN: 'This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback'
    √ should make no change when calling fs.exists()
    √ should update ctime, atime when calling fs.link()
    √ should make no change when calling fs.symlink()
    √ should make no change when calling fs.readlink()
    √ should update ctime, atime, mtime of parent dir when calling fs.unlink()
    √ should update ctime, atime, mtime of parent dir when calling fs.rmdir()
    √ should update ctime, atime, mtime of parent dir when calling fs.mkdir()
    √ should make no change when calling fs.close()
    √ should make no change when calling fs.open()
    √ should update atime, ctime, mtime when calling fs.write()
    √ should make no change when calling fs.read()
    √ should make no change when calling fs.readFile()
    √ should update atime, ctime, mtime when calling fs.writeFile()
    √ should update atime, ctime, mtime when calling fs.appendFile()
    √ should update ctime, atime when calling fs.setxattr()
    √ should update ctime, atime when calling fs.fsetxattr()
    √ should make no change when calling fs.getxattr()
    √ should make no change when calling fs.fgetxattr()
    √ should update ctime, atime when calling fs.removexattr()
    √ should update ctime, atime when calling fs.fremovexattr()
  node times (atime, mtime, ctime) with mount flags
    √ should not update ctime when calling fs.rename() with NOCTIME
    √ should not update ctime, mtime, atime when calling fs.truncate() with NOCTIME, NOMTIME
    √ should not update mtime when calling fs.truncate() with NOMTIME
  fs.watch
    √ should be a function
    √ should get a change event when writing a file
    √ should get a change event when writing a file beneath root dir with recursive=true
    √ should get a change event when writing a file in a dir with recursive=true
  Filer.Errors
    √ has expected errors
    √ should include all expected properties by default
    √ should include extra properties when provided
    √ should include default message and path info when provided
    √ should include just the message when no path provided
    √ should not include path in toString() when not provided
    √ should include path in toString() when provided
    √ should include message and path info when provided
  fs.Shell
    √ is a function
    √ should return a FileSystemShell instance
    √ should reflect changes to the prototype
  fs.chmod, fs.fchmod
    √ should be functions
    √ should automatically set mode=755 for a directory
    √ should automatically set mode=644 for a file
    √ should allow for updating mode of a given file
  fs.chown, fs.fchown
    √ should be functions
    √ should automatically set a file's uid and gid to 0 (i.e., root)
    √ should allow updating gid and uid for a file
  Filer.FileSystem.providers
    √ is defined
    √ has IndexedDB constructor
    √ has WebSQL constructor
    √ has Memory constructor
    √ has a Default constructor
    √ has Fallback constructor
  Filer Provider Tests for IndexedDB
    √ has open, getReadOnlyContext, and getReadWriteContext instance methods
    √ should open a new provider database
    √ should allow putObject() and getObject()
    √ should allow putBuffer() and getBuffer()
    √ should allow zero-length Buffers with putBuffer() and getBuffer()
    √ should allow delete()
    √ should allow clear()
  Filer Provider Tests for WebSQL
    √ has open, getReadOnlyContext, and getReadWriteContext instance methods
    √ should open a new provider database
    √ should allow putObject() and getObject()
    √ should allow putBuffer() and getBuffer()
    √ should allow zero-length Buffers with putBuffer() and getBuffer()
    √ should allow delete()
    √ should allow clear()
  Filer Provider Tests for Memory
    √ has open, getReadOnlyContext, and getReadWriteContext instance methods
    √ should open a new provider database
    √ should allow putObject() and getObject()
    √ should allow putBuffer() and getBuffer()
    √ should allow zero-length Buffers with putBuffer() and getBuffer()
    √ should allow delete()
    √ should allow clear()
  FileSystemShell.cd
    √ should be a function
    √ should default to a cwd of /
    √ should allow changing the path to a valid dir
    √ should fail when changing the path to an invalid dir
    √ should fail when changing the path to a file
    √ should allow relative paths for a valid dir
    √ should allow .. in paths for a valid dir
    √ should follow symlinks to dirs
  FileSystemShell.touch
    √ should be a function
    √ should create a new file if path does not exist
    √ should skip creating a new file if options.updateOnly is true
    √ should update times if path does exist
    √ should update times to specified date if path does exist
  FileSystemShell.exec
    √ should be a function
    √ should be able to execute a command .js file from the filesystem
  FileSystemShell.cat
    √ should be a function
    √ should fail when files argument is absent
    √ should return the contents of a single file
    √ should return the contents of multiple files
    √ should fail if any of multiple file paths is invalid
  FileSystemShell.ls
    √ should be a function
    √ should fail when dirs argument is absent
    √ should return the contents of a simple dir
    √ should return the shallow contents of a dir tree
    √ should return the deep contents of a dir tree
  FileSystemShell.rm
    √ should be a function
    √ should fail when path argument is absent
    √ should remove a single file
    √ should remove an empty dir
    √ should fail to remove a non-empty dir
    √ should remove a non-empty dir with option.recursive set
    √ should work on a complex dir structure
  FileSystemShell.env
    √ should get default env options
    √ should be able to specify env options
    √ should fail when dirs argument is absent
    √ should give new value for shell.pwd() when cwd changes
    √ should create/return the default tmp dir
    √ should create/return the tmp dir specified in env.TMP
    √ should allow repeated calls to tempDir()
  FileSystemShell.mkdirp
    √ should be a function
    √ should fail without a path provided
    √ should succeed if provided path is root
    √ should succeed if the directory exists
    √ fail if a file name is provided
WARN: 'This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback'
    √ should succeed on a folder on root ('/test')
WARN: 'This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback'
WARN: 'This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback'
    √ should succeed on a folder with a nonexistant parent ('/test/test')
    √ should fail on a folder with a file for its parent ('/test.txt/test')
  FileSystemShell.find
    √ should be a function
    √ should fail when path does not exist
    √ should fail when path exists but is non-dir
    √ should find all paths in the filesystem with no options
    √ should get same paths in exec as are found when complete
    √ should return only paths that match a regex pattern
    √ should append a / to the end of a dir path
    √ should only look below the specified dir path
    √ should allow using options.name to match basename with a pattern
    √ should allow using options.path to match dirname with a pattern
  node.js tests: https://github.com/joyent/node/blob/master/test/simple/test-fs-mkdir.js
    √ should create a dir without a mode arg
    √ should create a dir with a mode arg
  node.js tests: https://github.com/joyent/node/blob/master/test/simple/test-fs-null-bytes.js
    √ should reject paths with null bytes in them
  node.js tests: https://github.com/joyent/node/blob/master/test/simple/test-fs-watch.js
    √ should get change event for writeFile() using FSWatcher object
    √ should get change event for writeFile() using fs.watch() only
    √ should allow watches on dirs
  node.js tests: https://github.com/joyent/node/blob/master/test/simple/test-fs-watch-recursive.js
    √ should get change event for writeFile() under a recursive watched dir
  trailing slashes in path names, issue 105
    √ should deal with trailing slashes properly, path == path/
  fs.writeFile truncation - issue 106
    √ should truncate an existing file
  fs.writeFile and non-existing directory, issue 239
    √ should give ENOENT if writing to a dir that does not exist
  Filer.Buffer should accept initialized ArrayBuffers, issue 249
    √ should accept an ArrayBuffer with a specified size
  Filer.Buffer static methods are in tact, issue 249
    √ should proxy Buffer.isBuffer
    √ should proxy Buffer.isEncoding
    √ should proxy Buffer.byteLength
    √ should proxy Buffer.concat
  sh.ls and deep directory trees
    √ should not crash when calling sh.ls() on deep directory layouts
    √ should not crash when calling sh.ls() on wide directory layouts
  sh.cd doesn't seem to be working from a relative path if I am one or more folders deep, #247
    √ should properly deal with relative paths missing ./ and ../
  EISDIR when trying to open a dir path - issue 254
    √ should fail with EISDIR for root dir
    √ should fail with EISDIR for regular dir
    √ should fail with EISDIR for symlinked dir
  Queued operations should error when fs is in error state, issue 258
    √ should get EFILESYSTEMERROR errors on callbacks to queued operations on provider error
    √ should get EFILESYSTEMERROR errors on callbacks to queued operations after ready callback
  fs.readdir on non-dir paths, issue 267
    √ should fail with ENOTDIR when called on filepath
  undefined and relative paths, issue270
    √ should fail with EINVAL when called on an undefined path
    √ should fail with EINVAL when called on a relative path
  trailing slashes in path names to work when renaming a dir
    √ should deal with trailing slashes in rename, dir == dir/
  Path.resolve does not work, issue357
    √ Path.relative() should not crash
    √ Path.resolve() should work as expectedh
  Filer
    √ is defined
    √ has FileSystem constructor
    √ has Shell constructor
  Filer.FileSystem
    √ should properly mount new or existing filesystem
  fs
    √ is an object
    √ should have a root directory
    √ should be a function
    √ should return an error if path does not exist
    √ should return a stat object if path exists

Finished in 13.183 secs / 5.561 secs @ 20:47:30 GMT-0400 (Eastern Daylight Time)

SUMMARY:
√ 338 tests completed
```
</p>
</details>