### PR TITLE
Fix Issue #400 - add test for passing file to fs.promise.readdir()

### DIFF
--- a/tests/spec/fs.readdir.spec.js
+++ b/tests/spec/fs.readdir.spec.js
@@ -55,3 +55,25 @@ describe('fs.readdir', function() {
     });
   });
 });
+
+/**
+ * fsPromises tests
+ */
+
+describe('fsPromises.readdir', function() {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should return an error if the path is a file', function(done) {
+    var fsPromises = util.fs().promises;
+
+    fsPromises.open('/myfile', 'w')
+      .then(fd => fsPromises.close(fd))
+      .then(() => fsPromises.readdir('/myfile'))
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOTDIR');
+        done();
+      });
+  });
+});

--- a/tests/spec/fs.readdir.spec.js
+++ b/tests/spec/fs.readdir.spec.js
@@ -64,16 +64,15 @@ describe('fsPromises.readdir', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
-  it('should return an error if the path is a file', function(done) {
+  it('should return an error if the path is a file', function() {
     var fsPromises = util.fs().promises;
 
-    fsPromises.open('/myfile', 'w')
+    return fsPromises.open('/myfile', 'w')
       .then(fd => fsPromises.close(fd))
       .then(() => fsPromises.readdir('/myfile'))
       .catch(error => {
         expect(error).to.exist;
         expect(error.code).to.equal('ENOTDIR');
-        done();
       });
   });
 });


### PR DESCRIPTION
This adds a test to ensure that `fs.promise.readdir()` throws an error when passing in a file.