### PR TITLE
Fix #387 - Add test to write data to a file using the Promise API

### DIFF
--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -59,4 +59,31 @@ describe('fs.write', function() {
       });
     });
   });
+
+  /**
+   * fsPromise tests
+   */
+
+  it('should write data to a file using the Promise API', () => {
+    var fs = util.fs().promises;
+    var buffer = new Filer.Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    return fs.open('/myfile', 'w+')
+      .then((fd) => {
+        return fs.write(fd, buffer, 0, buffer.length, 0)
+          .then((result) => {
+            expect(result).to.equal(buffer.length);
+          });
+      })
+      .then(() => { 
+        return fs.stat('/myfile')
+          .then((result) => {
+            expect(result.type).to.equal('FILE');
+            expect(result.size).to.equal(buffer.length);
+          });
+      })
+      .catch((error) => {
+        if(error) throw error;
+      });
+  });
 });

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -69,21 +69,15 @@ describe('fs.write', function() {
     var buffer = new Filer.Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
 
     return fs.open('/myfile', 'w+')
-      .then((fd) => {
-        return fs.write(fd, buffer, 0, buffer.length, 0)
-          .then((result) => {
-            expect(result).to.equal(buffer.length);
-          });
+      .then(fd => fs.write(fd, buffer, 0, buffer.length, 0))
+      .then(result => {
+        expect(result).to.equal(buffer.length);
       })
-      .then(() => { 
-        return fs.stat('/myfile')
-          .then((result) => {
-            expect(result.type).to.equal('FILE');
-            expect(result.size).to.equal(buffer.length);
-          });
+      .then(() => fs.stat('/myfile'))
+      .then(result => {
+        expect(result.type).to.equal('FILE');
+        expect(result.size).to.equal(buffer.length);
       })
-      .catch((error) => {
-        if(error) throw error;
-      });
+      .catch(error => { throw error; });
   });
 });


### PR DESCRIPTION
This PR adds a new test to ensure that,

- a file was opened,
- a buffer of 8 numbers were successfully written to it,
- and check if the file is of type FILE,

using the Promise API.