### PR TITLE
fix issue#392-- add test for promises.rename() to rename existing file

### DIFF
--- a/tests/spec/fs.rename.spec.js
+++ b/tests/spec/fs.rename.spec.js
@@ -151,4 +151,44 @@ describe('fs.rename', function() {
       });
     });
   });
+
+  it('(promise version) should rename an existing file', function(done) {
+    var complete1 = false;
+    var complete2 = false;
+    var fs = util.fs();
+
+    function maybeDone() {
+      if(complete1 && complete2) {
+        done();
+      }
+    }
+
+    fs.open('/myfile', 'w+', function(error, fd) {
+      if(error) throw error;
+
+      fs.close(fd, function(error) {
+        if(error) throw error;
+
+        fs.promises.rename('/myfile', '/myotherfile').then(
+          function(){
+            fs.stat('/myfile', function(error, result) {
+              expect(error).to.exist;
+              expect(result).not.to.exist;
+              complete1 = true;
+              maybeDone();
+            });
+      
+            fs.stat('/myotherfile', function(error, result) {
+              expect(error).not.to.exist;
+              expect(result.nlinks).to.equal(1);
+              complete2 = true;
+              maybeDone();
+            });
+          },
+          function(error){throw error;}
+        );
+        
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds test for promises.rename() to tests/spec/fs.rename,spec.js to check renaming an existing file.

Closely mimics logic for an existing test that checks if the the Async rename() function renames an existing file (so no fs.promises functions are used for open(), close(), or stat() ).

Closes #392 

/cc @humphd 