### PR TITLE
Fix #423: added promise support to fs.stat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,12 +3278,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3298,17 +3300,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3425,7 +3430,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3437,6 +3443,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3451,6 +3458,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3458,12 +3466,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3482,6 +3492,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3562,7 +3573,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3574,6 +3586,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3695,6 +3708,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -92,3 +92,32 @@ describe('fs.stat', function() {
     });
   });
 });
+
+describe('fs.promises.stat', function() {
+    beforeEach(util.setup);
+    afterEach(util.cleanup);
+
+    it('should be a function', function() {
+        var fs = util.fs();
+        expect(fs.promises.stat).to.be.a('function');
+    });
+    
+    it('should return a stat object if file exists', function(done){
+        var fs = util.fs();
+
+        fs.promises.stat('/')
+            .then(result => { 
+                expect(result).to.exist;
+                expect(result['node']).to.be.a('string');
+                expect(result['dev']).to.equal(fs.name);
+                expect(result['size']).to.be.a('number');
+                expect(result['nlinks']).to.be.a('number');
+                expect(result['atime']).to.be.a('number');
+                expect(result['mtime']).to.be.a('number');
+                expect(result['ctime']).to.be.a('number');
+                expect(result['type']).to.equal('DIRECTORY');
+                done();
+            })
+            .catch(error => expect(error).not.to.exist);
+    });
+});


### PR DESCRIPTION
This pull request adds a test for fs.stat.promise when the path exists.