### PR TITLE
Fix #435: add a test for fsPromise.unlink() to delete a file that doe…

### DIFF
--- a/tests/spec/fs.unlink.spec.js
+++ b/tests/spec/fs.unlink.spec.js
@@ -105,7 +105,6 @@ describe('fs.unlink', function() {
   });
 });
 
-
 describe('fs.promises.unlink', function () {
   beforeEach(util.setup);
   afterEach(util.cleanup);
@@ -113,5 +112,15 @@ describe('fs.promises.unlink', function () {
   it('should be a function', function () {
     var fs = util.fs();
     expect(fs.promises.unlink).to.be.a('function');
+  });
+
+  it('should return an error if trying to delete a file that does not exist', function() {
+    var fsPromises = util.fs().promises;
+
+    return fsPromises.unlink('/myFile')
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOENT');
+      });
   });
 });


### PR DESCRIPTION
I wrote a test for `fsPromise.unlink()` to delete a file that does not exist. If the file does not exist, it can not be opened, and throw an error. https://github.com/filerjs/filer/issues/435