### PR TITLE
Fix issue-426: Add  the test for fsPromises.readdir when the path exsts, and is a directory

### DIFF
--- a/tests/spec/fs.readdir.spec.js
+++ b/tests/spec/fs.readdir.spec.js
@@ -54,4 +54,33 @@ describe('fs.readdir', function() {
       });
     });
   });
+
+  it('(promise) should be a function', function() {
+    var fsPromises = util.fs().promises;
+    expect(fsPromises.readdir).to.be.a('function');
+  });
+  
+  it('(promise) should return a list of files from an existing directory', function() {
+    var fsPromises = util.fs().promises;
+
+    return fsPromises.mkdir('/tmp')
+      .then(() => {
+        return fsPromises.stat('/');
+      })
+      .then(stats => {
+        expect(stats).to.exist;
+        expect(stats.isDirectory()).to.be.true;
+      })
+      .then(() => {
+        return fsPromises.readdir('/');
+      })
+      .then(files => {
+        expect(files).to.exist;
+        expect(files.length).to.equal(1);
+        expect(files[0]).to.equal('tmp');
+      })
+      .catch(error => {
+        expect(error).not.to.exist;
+      });
+  });
 });


### PR DESCRIPTION
I added two tests for fsPromises.readdir function to ensure that fsPromises.readdir is a function, and it returns the contents of the directory if the path given exists and is a directory.

I was not sure if I should create new group for fsPromises.readdir test cases(i.e. describe(...) ), so I simply added under fs.readdir test cases by adding '(promise)' in the front.

I also checked [PR-issue-400](https://github.com/filerjs/filer/pull/409). It seems like there is a conflict between my tests and @jespirit 's test in terms of how fsPromises tests are written.

Any advice for this?