### PR TITLE
Issue 427 - Add tests to fsPromises.rmdir when directory doesn't exist and when trying to delete root directory

### DIFF
--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -97,4 +97,28 @@ describe('fs.rmdir', function() {
       });
     });
   });
+
+  it('(promise) should be a function', function() {
+    var fsPromises = util.fs().promises;
+    expect(fsPromises.rmdir).to.be.a('function');
+  });
+  
+  it('(promise) should return an error if the path does not exist', function() {
+    var fsPromises = util.fs().promises;
+      return fsPromises.rmdir('/tmp/mydir')
+        .catch(error => {
+          expect(error).to.exist;
+          expect(error.code).to.equal('ENOENT');
+        });
+  });
+
+  it('(promise) should return an error if attempting to remove the root directory', function(done) {
+    var fsPromises = util.fs().promises;
+      return fsPromises.rmdir('/')
+        .catch(error => {
+          expect(error).to.exist;
+          expect(error.code).to.equal('ENOENT');
+        });
+  });
 });
+

--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -105,20 +105,20 @@ describe('fs.rmdir', function() {
   
   it('(promise) should return an error if the path does not exist', function() {
     var fsPromises = util.fs().promises;
-      return fsPromises.rmdir('/tmp/mydir')
-        .catch(error => {
-          expect(error).to.exist;
-          expect(error.code).to.equal('ENOENT');
-        });
+    return fsPromises.rmdir('/tmp/mydir')
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOENT');
+      });
   });
 
-  it('(promise) should return an error if attempting to remove the root directory', function(done) {
+  it('(promise) should return an error if attempting to remove the root directory', function() {
     var fsPromises = util.fs().promises;
-      return fsPromises.rmdir('/')
-        .catch(error => {
-          expect(error).to.exist;
-          expect(error.code).to.equal('ENOENT');
-        });
+    return fsPromises.rmdir('/')
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('EBUSY');
+      });
   });
 });
 

--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -121,4 +121,3 @@ describe('fs.rmdir', function() {
       });
   });
 });
-


### PR DESCRIPTION
For issue #427, I've added two tests for fsPromises.rmdir for the following:

1) The user tries to remove a non-existent directory
2) The user tries to remove the root directory

Hopefully everything is fine!