### PR TITLE
Issue 417 - Added test for fs.promises.rename to rename existing directory

### DIFF
--- a/tests/spec/fs.rename.spec.js
+++ b/tests/spec/fs.rename.spec.js
@@ -75,8 +75,7 @@ describe('fs.rename', function() {
 
     return fsPromises.mkdir('/mydir')
       .then(() => {
-        return fsPromises.rename('/mydir', '/myotherdir')
-          .catch((error) => expect(error).not.to.exist);
+        return fsPromises.rename('/mydir', '/myotherdir');
       })
       .then(() => {
         return fsPromises.stat('/mydir')

--- a/tests/spec/fs.rename.spec.js
+++ b/tests/spec/fs.rename.spec.js
@@ -74,22 +74,17 @@ describe('fs.rename', function() {
     var fsPromises = util.fs().promises;
 
     return fsPromises.mkdir('/mydir')
-      .then(() => {
-        return fsPromises.rename('/mydir', '/myotherdir');
+      .then(() => fsPromises.rename('/mydir', '/myotherdir'))
+      .then(() => { fsPromises.stat('/mydir')
+        .catch((error) => {
+          expect(error).to.exist;
+          expect(error.code).to.equal('ENOENT');
+        });
       })
-      .then(() => {
-        return fsPromises.stat('/mydir')
-          .catch((error) => {
-            expect(error).to.exist;
-            expect(error.code).to.equal('ENOENT');
-          });
-      })
-      .then(() => {
-        return fsPromises.stat('/myotherdir')
-          .catch((error, result) => {
-            expect(error).not.to.exist;
-            expect(result.nlinks).to.equal(1);
-          });
+      .then(() => { fsPromises.stat('/myotherdir')
+        .then(result => {
+          expect(result.nlinks).to.equal(1);
+        });
       })
       .catch((error) => {
         if (error) throw error;

--- a/tests/spec/fs.rename.spec.js
+++ b/tests/spec/fs.rename.spec.js
@@ -70,6 +70,31 @@ describe('fs.rename', function() {
     });
   });
 
+  it('should rename an existing directory (using promises)', function(done) {
+    var fs = util.fs();
+
+    fs.mkdir('/mydir', function(error) {
+      if(error) throw error;
+
+      fs.promises.rename('/mydir', '/myotherdir').then(
+      function() {
+        expect(error).not.to.exist;
+        fs.stat('/mydir', function(error) {
+          expect(error).to.exist;
+          expect(error.code).to.equal('ENOENT');
+
+          fs.stat('/myotherdir', function(error, result) {
+            expect(error).not.to.exist;
+            expect(result.nlinks).to.equal(1);
+            done();
+          });
+        });
+      },
+      function(error){throw error;}
+      );
+    });
+  });
+
   it('should rename an existing directory if the new path points to an existing directory', function(done) {
     var fs = util.fs();
 

--- a/tests/spec/fs.rename.spec.js
+++ b/tests/spec/fs.rename.spec.js
@@ -77,20 +77,20 @@ describe('fs.rename', function() {
       if(error) throw error;
 
       fs.promises.rename('/mydir', '/myotherdir').then(
-      function() {
-        expect(error).not.to.exist;
-        fs.stat('/mydir', function(error) {
-          expect(error).to.exist;
-          expect(error.code).to.equal('ENOENT');
+        function() {
+          expect(error).not.to.exist;
+          fs.stat('/mydir', function(error) {
+            expect(error).to.exist;
+            expect(error.code).to.equal('ENOENT');
 
-          fs.stat('/myotherdir', function(error, result) {
-            expect(error).not.to.exist;
-            expect(result.nlinks).to.equal(1);
-            done();
+            fs.stat('/myotherdir', function(error, result) {
+              expect(error).not.to.exist;
+              expect(result.nlinks).to.equal(1);
+              done();
+            });
           });
-        });
-      },
-      function(error){throw error;}
+        },
+        function(error){throw error;}
       );
     });
   });

--- a/tests/spec/fs.rename.spec.js
+++ b/tests/spec/fs.rename.spec.js
@@ -70,29 +70,31 @@ describe('fs.rename', function() {
     });
   });
 
-  it('should rename an existing directory (using promises)', function(done) {
-    var fs = util.fs();
+  it('should rename an existing directory (using promises)', () => {
+    var fsPromises = util.fs().promises;
 
-    fs.mkdir('/mydir', function(error) {
-      if(error) throw error;
-
-      fs.promises.rename('/mydir', '/myotherdir').then(
-        function() {
-          expect(error).not.to.exist;
-          fs.stat('/mydir', function(error) {
+    return fsPromises.mkdir('/mydir')
+      .then(() => {
+        return fsPromises.rename('/mydir', '/myotherdir')
+          .catch((error) => expect(error).not.to.exist);
+      })
+      .then(() => {
+        return fsPromises.stat('/mydir')
+          .catch((error) => {
             expect(error).to.exist;
             expect(error.code).to.equal('ENOENT');
-
-            fs.stat('/myotherdir', function(error, result) {
-              expect(error).not.to.exist;
-              expect(result.nlinks).to.equal(1);
-              done();
-            });
           });
-        },
-        function(error){throw error;}
-      );
-    });
+      })
+      .then(() => {
+        return fsPromises.stat('/myotherdir')
+          .catch((error, result) => {
+            expect(error).not.to.exist;
+            expect(result.nlinks).to.equal(1);
+          });
+      })
+      .catch((error) => {
+        if (error) throw error;
+      });
   });
 
   it('should rename an existing directory if the new path points to an existing directory', function(done) {


### PR DESCRIPTION
Added test for fs.promises.rename() to rename a directory which already exists.

[Link to issue](https://github.com/filerjs/filer/issues/417)

Any feedback appreciated!