### PR TITLE
Fix #421 - Add test for fs.promises.link to ensure it returns a Promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,14 +3278,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3300,20 +3298,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3430,8 +3425,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3443,7 +3437,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3458,7 +3451,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3466,14 +3458,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3492,7 +3482,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3573,8 +3562,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3586,7 +3574,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3708,7 +3695,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,12 +3278,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3298,17 +3300,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3425,7 +3430,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3437,6 +3443,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3451,6 +3458,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3458,12 +3466,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3482,6 +3492,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3562,7 +3573,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3574,6 +3586,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3695,6 +3708,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/tests/spec/fs.link.spec.js
+++ b/tests/spec/fs.link.spec.js
@@ -1,6 +1,7 @@
 var util = require('../lib/test-utils.js');
 var expect = require('chai').expect;
 
+
 describe('fs.link', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
@@ -80,7 +81,7 @@ describe('fs.link', function() {
 
           fs.lstat('/myfileLink', function (error, result) {
             if (error) throw error;
-            
+
             var _linkstats = result;
             fs.lstat('/myotherfile', function (error, result) {
               expect(error).not.to.exist;
@@ -110,4 +111,15 @@ describe('fs.link', function() {
       });
     });
   });
+
+  describe('fs.promises.link', function() {
+
+    it('should return a promise', function() {
+      var fs = util.fs().promises; //should be in test-utils.js?
+      var returnValue = fs.link('/myfile', '/myotherfile');
+      expect(returnValue).to.be.a('promise');
+    });
+
+  });
+
 });

--- a/tests/spec/fs.link.spec.js
+++ b/tests/spec/fs.link.spec.js
@@ -120,9 +120,9 @@ describe('fs.promises.link', function() {
   afterEach(util.cleanup);
 
   it('should return a promise', function() {
-    var fs = util.fs().promises; //should be in test-utils.js?
+    var fs = util.fs().promises;
     var returnValue = fs.link('/myfile', '/myotherfile');
-    expect(returnValue).to.be.a('promise');
+    expect(obj).to.be.a('promise');
   });
 
 });

--- a/tests/spec/fs.link.spec.js
+++ b/tests/spec/fs.link.spec.js
@@ -118,8 +118,8 @@ describe('fs.promises.link', function() {
   afterEach(util.cleanup);
 
   it('should return a promise', function() {
-    var fs = util.fs().promises;
-    var returnValue = fs.link('/myfile', '/myotherfile');
+    var fsPromise = util.fs().promises;
+    var returnValue = fsPromise.link('/myfile', '/myotherfile');
     expect(returnValue).to.be.a('promise');
   });
 

--- a/tests/spec/fs.link.spec.js
+++ b/tests/spec/fs.link.spec.js
@@ -112,14 +112,17 @@ describe('fs.link', function() {
     });
   });
 
-  describe('fs.promises.link', function() {
+});
 
-    it('should return a promise', function() {
-      var fs = util.fs().promises; //should be in test-utils.js?
-      var returnValue = fs.link('/myfile', '/myotherfile');
-      expect(returnValue).to.be.a('promise');
-    });
+describe('fs.promises.link', function() {
 
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should return a promise', function() {
+    var fs = util.fs().promises; //should be in test-utils.js?
+    var returnValue = fs.link('/myfile', '/myotherfile');
+    expect(returnValue).to.be.a('promise');
   });
 
 });

--- a/tests/spec/fs.link.spec.js
+++ b/tests/spec/fs.link.spec.js
@@ -1,7 +1,6 @@
 var util = require('../lib/test-utils.js');
 var expect = require('chai').expect;
 
-
 describe('fs.link', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
@@ -81,7 +80,6 @@ describe('fs.link', function() {
 
           fs.lstat('/myfileLink', function (error, result) {
             if (error) throw error;
-
             var _linkstats = result;
             fs.lstat('/myotherfile', function (error, result) {
               expect(error).not.to.exist;
@@ -122,7 +120,7 @@ describe('fs.promises.link', function() {
   it('should return a promise', function() {
     var fs = util.fs().promises;
     var returnValue = fs.link('/myfile', '/myotherfile');
-    expect(obj).to.be.a('promise');
+    expect(returnValue).to.be.a('promise');
   });
 
 });


### PR DESCRIPTION
Closes issue [#421](https://github.com/filerjs/filer/issues/421)

Adds test for `fs.promises.link` in `fs.link.spec.js` to test if the method returns a promise. 
If anyone has any comments/suggestions relating to this pull request, feel free to say so.