### PR TITLE
Fixes #420 - Setting a mode for a new file, when opening it. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,14 +3278,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3300,20 +3298,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3430,8 +3425,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3443,7 +3437,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3458,7 +3451,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3466,14 +3458,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3492,7 +3482,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3573,8 +3562,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3586,7 +3574,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3708,7 +3695,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,12 +3278,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3298,17 +3300,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3425,7 +3430,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3437,6 +3443,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3451,6 +3458,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3458,12 +3466,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3482,6 +3492,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3562,7 +3573,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3574,6 +3586,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3695,6 +3708,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1924,7 +1924,6 @@ function isUint32(value) {
 // Validator for mode_t (the S_* constants). Valid numbers or octal strings
 // will be masked with 0o777 to be consistent with the behavior in POSIX APIs.
 function validateAndMaskMode(value, def, callback) {
-  console.log('Passed in mode: ' + value);
   if(typeof def === 'function') {
     callback = def;
     def = undefined;
@@ -1932,7 +1931,6 @@ function validateAndMaskMode(value, def, callback) {
 
   if (isUint32(value)) {
     let newMode = value & FULL_READ_WRITE_EXEC_PERMISSIONS;
-    console.log('Masked mode: ' + newMode);
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 
@@ -1953,7 +1951,6 @@ function validateAndMaskMode(value, def, callback) {
       return false;
     }
     var parsed = parseInt(value, 8);
-    console.log('Parsed + Masekd mode: ' + parsed & FULL_READ_WRITE_EXEC_PERMISSIONS);
     return parsed & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1629,7 +1629,7 @@ function open(fs, context, path, flags, mode, callback) {
   */
   if (arguments.length == 5){
     callback = arguments[arguments.length - 1];
-    mode = 0o666;
+    mode = 0o644;
   }
   else {
     //need to test this validateAndMakeMode
@@ -1928,8 +1928,8 @@ function validateAndMaskMode(value, def, callback) {
     callback = def;
     def = undefined;
   }
-
   if (isUint32(value)) {
+    let newMode = value & FULL_READ_WRITE_EXEC_PERMISSIONS;
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1623,8 +1623,16 @@ function open(fs, context, path, flags, mode, callback) {
    *    callback = makeCallback(callback);
    * }
   */
-
-  callback = arguments[arguments.length - 1];
+   if (arguments.length == 5){
+      callback = arguments[arguments.length - 1];
+    }
+    else {
+      //need to test this validateAndMakeMode
+      console.log("open'd mode: " + mode)
+      mode = validateAndMaskMode(mode, FULL_READ_WRITE_EXEC_PERMISSIONS, callback);
+      console.log("mask'd mode: " + mode)
+    }
+    
   if(!pathCheck(path, callback)) return;
 
   function check_result(error, fileNode) {
@@ -1913,12 +1921,15 @@ function isUint32(value) {
 // Validator for mode_t (the S_* constants). Valid numbers or octal strings
 // will be masked with 0o777 to be consistent with the behavior in POSIX APIs.
 function validateAndMaskMode(value, def, callback) {
+  console.log("Passed in mode: " + value)
   if(typeof def === 'function') {
     callback = def;
     def = undefined;
   }
 
   if (isUint32(value)) {
+    let newMode = value & FULL_READ_WRITE_EXEC_PERMISSIONS;
+    console.log("Masked mode: " + newMode)
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 
@@ -1939,6 +1950,7 @@ function validateAndMaskMode(value, def, callback) {
       return false;
     }
     var parsed = parseInt(value, 8);
+    console.log("Parsed + Masekd mode: " + parsed & FULL_READ_WRITE_EXEC_PERMISSIONS)
     return parsed & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -534,8 +534,9 @@ function remove_directory(context, path, callback) {
 }
 
 function open_file(context, path, flags, mode, callback) {
-  if (typeof mode == 'function'){
+  if (typeof mode === 'function'){
     callback = mode;
+    mode = null
   }
   path = normalize(path);
   var name = basename(path);
@@ -648,7 +649,9 @@ function open_file(context, path, flags, mode, callback) {
       }
       fileNode = result;
       fileNode.nlinks += 1;
-      if(mode){Node.setMode(mode, fileNode);}
+      if(mode){
+        Node.setMode(mode, fileNode);
+      }
       context.putObject(fileNode.id, fileNode, write_file_data);
     });
   }
@@ -1627,12 +1630,11 @@ function open(fs, context, path, flags, mode, callback) {
    *    callback = makeCallback(callback);
    * }
   */
-  if (arguments.length == 5){
+  if (arguments.length < 6 ){
     callback = arguments[arguments.length - 1];
     mode = 0o644;
   }
   else {
-    //need to test this validateAndMakeMode
     mode = validateAndMaskMode(mode, FULL_READ_WRITE_EXEC_PERMISSIONS, callback);
   }
     

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1615,21 +1615,6 @@ function pathCheck(path, allowRelative, callback) {
 
 
 function open(fs, context, path, flags, mode, callback) {
-  /**
-   * NOTE: we support the same signature as node with a `mode` arg,
-   * but ignore it. We need to add it.  Here is what node.js does:
-   * function open(path, flags, mode, callback) {
-   *    path = getPathFromURL(path);
-   *  validatePath(path);
-   *  const flagsNumber = stringToFlags(flags);
-   *  if (arguments.length < 4) {
-   *    callback = makeCallback(mode);
-   *    mode = 0o666;
-   *  } else {
-   *    mode = validateAndMaskMode(mode, 'mode', 0o666);
-   *    callback = makeCallback(callback);
-   * }
-  */
   if (arguments.length < 6 ){
     callback = arguments[arguments.length - 1];
     mode = 0o644;
@@ -1930,7 +1915,7 @@ function validateAndMaskMode(value, def, callback) {
     callback = def;
     def = undefined;
   }
-  
+
   if (isUint32(value)) {
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1930,6 +1930,7 @@ function validateAndMaskMode(value, def, callback) {
     callback = def;
     def = undefined;
   }
+  
   if (isUint32(value)) {
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -536,7 +536,7 @@ function remove_directory(context, path, callback) {
 function open_file(context, path, flags, mode, callback) {
   if (typeof mode === 'function'){
     callback = mode;
-    mode = null
+    mode = null;
   }
   path = normalize(path);
   var name = basename(path);

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -533,7 +533,10 @@ function remove_directory(context, path, callback) {
   find_node(context, parentPath, read_parent_directory_data);
 }
 
-function open_file(context, path, flags, callback) {
+function open_file(context, path, flags, mode, callback) {
+  if (typeof mode == 'function'){
+    callback = mode;
+  }
   path = normalize(path);
   var name = basename(path);
   var parentPath = dirname(path);
@@ -645,6 +648,7 @@ function open_file(context, path, flags, callback) {
       }
       fileNode = result;
       fileNode.nlinks += 1;
+      if(mode){Node.setMode(mode, fileNode);}
       context.putObject(fileNode.id, fileNode, write_file_data);
     });
   }
@@ -1625,12 +1629,11 @@ function open(fs, context, path, flags, mode, callback) {
   */
   if (arguments.length == 5){
     callback = arguments[arguments.length - 1];
+    mode = 0o666;
   }
   else {
     //need to test this validateAndMakeMode
-    console.log('open\'d mode: ' + mode);
     mode = validateAndMaskMode(mode, FULL_READ_WRITE_EXEC_PERMISSIONS, callback);
-    console.log('mask\'d mode: ' + mode);
   }
     
   if(!pathCheck(path, callback)) return;
@@ -1656,7 +1659,7 @@ function open(fs, context, path, flags, mode, callback) {
     callback(new Errors.EINVAL('flags is not valid'), path);
   }
 
-  open_file(context, path, flags, check_result);
+  open_file(context, path, flags, mode, check_result);
 }
 
 function close(fs, context, fd, callback) {

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1929,7 +1929,6 @@ function validateAndMaskMode(value, def, callback) {
     def = undefined;
   }
   if (isUint32(value)) {
-    let newMode = value & FULL_READ_WRITE_EXEC_PERMISSIONS;
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1930,7 +1930,6 @@ function validateAndMaskMode(value, def, callback) {
   }
 
   if (isUint32(value)) {
-    let newMode = value & FULL_READ_WRITE_EXEC_PERMISSIONS;
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1623,15 +1623,15 @@ function open(fs, context, path, flags, mode, callback) {
    *    callback = makeCallback(callback);
    * }
   */
-   if (arguments.length == 5){
-      callback = arguments[arguments.length - 1];
-    }
-    else {
-      //need to test this validateAndMakeMode
-      console.log("open'd mode: " + mode)
-      mode = validateAndMaskMode(mode, FULL_READ_WRITE_EXEC_PERMISSIONS, callback);
-      console.log("mask'd mode: " + mode)
-    }
+  if (arguments.length == 5){
+    callback = arguments[arguments.length - 1];
+  }
+  else {
+    //need to test this validateAndMakeMode
+    console.log('open\'d mode: ' + mode);
+    mode = validateAndMaskMode(mode, FULL_READ_WRITE_EXEC_PERMISSIONS, callback);
+    console.log('mask\'d mode: ' + mode);
+  }
     
   if(!pathCheck(path, callback)) return;
 
@@ -1921,7 +1921,7 @@ function isUint32(value) {
 // Validator for mode_t (the S_* constants). Valid numbers or octal strings
 // will be masked with 0o777 to be consistent with the behavior in POSIX APIs.
 function validateAndMaskMode(value, def, callback) {
-  console.log("Passed in mode: " + value)
+  console.log('Passed in mode: ' + value);
   if(typeof def === 'function') {
     callback = def;
     def = undefined;
@@ -1929,7 +1929,7 @@ function validateAndMaskMode(value, def, callback) {
 
   if (isUint32(value)) {
     let newMode = value & FULL_READ_WRITE_EXEC_PERMISSIONS;
-    console.log("Masked mode: " + newMode)
+    console.log('Masked mode: ' + newMode);
     return value & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 
@@ -1950,7 +1950,7 @@ function validateAndMaskMode(value, def, callback) {
       return false;
     }
     var parsed = parseInt(value, 8);
-    console.log("Parsed + Masekd mode: " + parsed & FULL_READ_WRITE_EXEC_PERMISSIONS)
+    console.log('Parsed + Masekd mode: ' + parsed & FULL_READ_WRITE_EXEC_PERMISSIONS);
     return parsed & FULL_READ_WRITE_EXEC_PERMISSIONS;
   }
 

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -123,7 +123,6 @@ describe('fs.open', function() {
     });
   });
 
-  
   /**
    * This test is currently correct per our code, but incorrect according to the spec.
    * When we fix https://github.com/filerjs/filer/issues/314 we'll have to update this.

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -117,7 +117,7 @@ describe('fs.open', function() {
         expect(result).to.exist;
         expect(result.type).to.equal('FILE');
         expect(result.mode).to.exist;
-        expect(result.mode).to.equal(33188)
+        expect(result.mode).to.equal(33188);
         done();
       });
     });

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -106,22 +106,6 @@ describe('fs.open', function() {
     });
   });
 
-  it('should create a new file when flagged for write, and set the mode', function(done) {
-    var fs = util.fs();
-
-    fs.open('/myfile', 'w', 644, function(error) {
-      if(error) throw error;
-      
-      fs.stat('/myfile', function(error, result) {
-        expect(error).not.to.exist;
-        expect(result).to.exist;
-        expect(result.type).to.equal('FILE');
-        expect(result.mode).to.exist;
-        expect(result.mode).to.equal(33188);
-        done();
-      });
-    });
-  });
   /**
    * This test is currently correct per our code, but incorrect according to the spec.
    * When we fix https://github.com/filerjs/filer/issues/314 we'll have to update this.

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -106,6 +106,22 @@ describe('fs.open', function() {
     });
   });
 
+  it('should create a new file when flagged for write, and set the mode', function(done) {
+    var fs = util.fs();
+
+    fs.open('/myfile', 'w', 644, function(error) {
+      if(error) throw error;
+      
+      fs.stat('/myfile', function(error, result) {
+        expect(error).not.to.exist;
+        expect(result).to.exist;
+        expect(result.type).to.equal('FILE');
+        expect(result.mode).to.exist;
+        expect(result.mode).to.equal(33188)
+        done();
+      });
+    });
+  });
   /**
    * This test is currently correct per our code, but incorrect according to the spec.
    * When we fix https://github.com/filerjs/filer/issues/314 we'll have to update this.

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -123,6 +123,22 @@ describe('fs.open', function() {
     });
   });
 
+  it('should create a new file, but no mode is passed, so  the default value of 644 should be seen', function(done) {
+
+    var fs = util.fs();
+    fs.open('/myfile', 'w', function(error) {
+      if(error) throw error;
+
+      fs.stat('/myfile', function(error, result) {
+        expect(error).not.to.exist;
+        expect(result).to.exist;
+        expect(result.mode).to.exist;
+        expect(result.mode & 0o644).to.equal(0o644);
+        done();
+      });
+    });
+  });
+
   /**
    * This test is currently correct per our code, but incorrect according to the spec.
    * When we fix https://github.com/filerjs/filer/issues/314 we'll have to update this.

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -106,6 +106,24 @@ describe('fs.open', function() {
     });
   });
 
+
+  it('should create a new file, when flagged for write, and set the mode to the passed value', function(done) {
+
+    var fs = util.fs();
+    fs.open('/myfile', 'w', 0o777, function(error) {
+      if(error) throw error;
+
+      fs.stat('/myfile', function(error, result) {
+        expect(error).not.to.exist;
+        expect(result).to.exist;
+        expect(result.mode).to.exist;
+        expect(result.mode & 0o777).to.equal(0o777);
+        done();
+      });
+    });
+  });
+
+  
   /**
    * This test is currently correct per our code, but incorrect according to the spec.
    * When we fix https://github.com/filerjs/filer/issues/314 we'll have to update this.


### PR DESCRIPTION
This fixes issue (https://github.com/filerjs/filer/issues/420) 

1.  a `mode` has been added to the [`fs.open_file`](https://github.com/filerjs/filer/blob/e3a1187ef94d5fc627768cee13457417e7ea0035/src/filesystem/implementation.js#L536) function definition

2.  only when a mode argument is passed: the `mode` is then associated with the new `Node`.
     if no argument, a mode value is still set the default file option of 0o644.

3.  a test has been created to ensure that if a mode is passed in as an argument for the [`fs.open`](https://github.com/filerjs/filer/blob/e3a1187ef94d5fc627768cee13457417e7ea0035/src/filesystem/implementation.js#L1610) function, the mode exists as it should. 

Would still be nice to... 
- test to ensure that mode's do not change when opening existing files, and passsing in a mode options.
- thinking of more ways to break this code would be helpful too. 