### PR TITLE
Fix #411: Tests if event is thrown when calling rename

### DIFF
--- a/tests/spec/fs.watch.spec.js
+++ b/tests/spec/fs.watch.spec.js
@@ -70,7 +70,7 @@ describe('fs.watch', function() {
 
     fs.writeFile('/myfile', 'data', function(error) {
       if(error) throw error;
-    })
+    });
 
     var watcher = fs.watch('/myfile', function(event, filename) {
       expect(event).to.equal('change');

--- a/tests/spec/fs.watch.spec.js
+++ b/tests/spec/fs.watch.spec.js
@@ -64,4 +64,23 @@ describe('fs.watch', function() {
       });
     });
   });
+
+  it('should get a change event when renaming a file', function(done) {
+    var fs = util.fs();
+
+    fs.writeFile('/myfile', 'data', function(error) {
+      if(error) throw error;
+    })
+
+    var watcher = fs.watch('/myfile', function(event, filename) {
+      expect(event).to.equal('change');
+      expect(filename).to.equal('/myfile');
+      watcher.close();
+      done();
+    });
+
+    fs.rename('/myfile', '/mynewfile', function(error) {
+      if(error) throw error;
+    });
+  });
 });

--- a/tests/spec/fs.watch.spec.js
+++ b/tests/spec/fs.watch.spec.js
@@ -72,6 +72,8 @@ describe('fs.watch', function() {
       if(error) throw error;
     });
 
+    //Normaly A 'rename' event should be thrown, but filer doesn't support that event at this time.
+    //For now renaming a file will throw a change event.
     var watcher = fs.watch('/myfile', function(event, filename) {
       expect(event).to.equal('change');
       expect(filename).to.equal('/myfile');


### PR DESCRIPTION
Could not make the `change` event to throw `rename` during a rename call.

Test will check if `change` event is thrown when a file is renamed.