### PR TITLE
Fix #414 - add recursive option for mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Filer is as close to the node.js [fs module](http://nodejs.org/api/fs.html) as p
 with the following differences:
 
 * No synchronous versions of methods (e.g., `mkdir()` but not `mkdirSync()`).
-* No permissions (e.g., no `chown()`, `chmod()`, etc.).
 * No support for stream-based operations (e.g., `fs.ReadStream`, `fs.WriteStream`).
 
 Filer has other features lacking in node.js (e.g., swappable backend
@@ -305,7 +304,7 @@ var fs = new Filer.FileSystem();
 * [fs.unlink(path, callback)](#unlink)
 * [fs.mknod(path, mode, callback)](#mknod)
 * [fs.rmdir(path, callback)](#rmdir)
-* [fs.mkdir(path, [mode], callback)](#mkdir)
+* [fs.mkdir(path, [options], callback)](#mkdir)
 * [fs.readdir(path, callback)](#readdir)
 * [fs.close(fd, callback)](#close)
 * [fs.open(path, flags, [mode], callback)](#open)
@@ -653,11 +652,15 @@ fs.unlink('/docs/a.txt', function(err) {
 });
 ```
 
-#### fs.mkdir(path, [mode], callback)<a name="mkdir"></a>
+#### fs.mkdir(path, [options], callback)<a name="mkdir"></a>
 
 Makes a directory with name supplied in `path` argument. Asynchronous [mkdir(2)](http://pubs.opengroup.org/onlinepubs/009695399/functions/mkdir.html). Callback gets no additional arguments.
 
-NOTE: Filer allows for, but ignores the optional `mode` argument used in node.js.
+`options` can be an `Object`, `Number`, or `String`.  If a `Number` or `String`, it is
+considered a `mode`. Note: Filer allows for a `mode`, but currently ignores it.  If `options`
+is an `Object`, it can contain: 1) `recursive` (`Boolean`) property, indicating whether or not
+parent paths should first be created (defaults to `false`); 2) `mode` (`Number`/`String`) property,
+indicating a `mode` as discussed above.
 
 Example:
 
@@ -670,6 +673,12 @@ fs.mkdir('/home', function(err) {
     if(err) throw err;
     // directory /home/carl now exists
   });
+});
+
+// Create /home/guest/tim recursively
+fs.mkdir('/home/guest/tim', {recursive: true}, function(err) {
+  if(err) throw err;
+  // directories /home/guest/tim now exist
 });
 ```
 
@@ -1531,9 +1540,11 @@ sh.tempDir(function(err, tmp) {
 
 #### sh.mkdirp(path, callback)<a name="mkdirp"></a>
 
-Recursively creates the directory at the provided path. If the
-directory already exists, no error is returned. All parents must
-be valid directories (not files).
+Recursively creates the directory at the provided path. If the directory already
+exists, no error is returned. All parents must be valid directories (not files).
+
+NOTE: This is simply a convenience for calling [`fs.mkdir(path, {recursive: true}, callback)`](#mkdir),
+which is the preferred way to accomplish recursive directory creation.
 
 Example:
 

--- a/src/shell/shell.js
+++ b/src/shell/shell.js
@@ -372,71 +372,11 @@ Shell.prototype.tempDir = function(callback) {
 };
 
 /**
- * Recursively creates the directory at `path`. If the parent
- * of `path` does not exist, it will be created.
- * Based off EnsureDir by Sam X. Xu
- * https://www.npmjs.org/package/ensureDir
- * MIT License
+ * Pass through to fs.mkdir with options = {recursive:true}, which does what we need now.
  */
 Shell.prototype.mkdirp = function(path, callback) {
-  var sh = this;
-  var fs = sh.fs;
-  callback = callback || function(){};
-
-  if(!path) {
-    callback(new Errors.EINVAL('Missing path argument'));
-    return;
-  }
-  else if (path === '/') {
-    callback();
-    return;
-  }
-  function _mkdirp(path, callback) {
-    fs.stat(path, function (err, stat) {
-      if(stat) {
-        if(stat.isDirectory()) {
-          callback();
-          return;
-        }
-        else if (stat.isFile()) {
-          callback(new Errors.ENOTDIR(null, path));
-          return;
-        }
-      }
-      else if (err && err.code !== 'ENOENT') {
-        callback(err);
-        return;
-      }
-      else {
-        var parent = Path.dirname(path);
-        if(parent === '/') {
-          fs.mkdir(path, function (err) {
-            if (err && err.code != 'EEXIST') {
-              callback(err);
-              return;
-            }
-            callback();
-            return;
-          });
-        }
-        else {
-          _mkdirp(parent, function (err) {
-            if (err) return callback(err);
-            fs.mkdir(path, function (err) {
-              if (err && err.code != 'EEXIST') {
-                callback(err);
-                return;
-              }
-              callback();
-              return;
-            });
-          });
-        }
-      }
-    });
-  }
-
-  _mkdirp(path, callback);
+  var fs = this.fs;
+  fs.mkdir(path, {recursive: true}, callback);
 };
 
 /**

--- a/tests/spec/fs.mkdir.spec.js
+++ b/tests/spec/fs.mkdir.spec.js
@@ -82,4 +82,16 @@ describe('fs.mkdir', function() {
     });
   });
 
+  it('should create all paths if {recursive:true} is specified on a deep path (promises)', () => {
+    let fsPromises = util.fs().promises;
+
+    return fsPromises
+      .mkdir('/tmp/deep/path', {recursive:true})
+      .then(() => fsPromises.stat('/tmp/deep/path'))
+      .then(stats => {
+        expect(stats).to.exist;
+        expect(stats.type).to.equal('DIRECTORY');
+      });
+  });
+
 });

--- a/tests/spec/fs.mkdir.spec.js
+++ b/tests/spec/fs.mkdir.spec.js
@@ -45,4 +45,41 @@ describe('fs.mkdir', function() {
       });
     });
   });
+
+  it('should error if {recursive:true} is not specified on a deep path', function(done) {
+    var fs = util.fs();
+
+    fs.mkdir('/tmp/deep/path', function(error) {
+      expect(error).to.exist;
+      expect(error.code).to.equal('ENOENT');
+      done();
+    });
+  });
+
+  it('should error if only a mode is specified on a deep path (should default to recursive:false)', function(done) {
+    var fs = util.fs();
+
+    fs.mkdir('/tmp/deep/path', 0o777, function(error) {
+      expect(error).to.exist;
+      expect(error.code).to.equal('ENOENT');
+      done();
+    });
+  });
+
+  it('should create all paths if {recursive:true} is specified on a deep path', function(done) {
+    var fs = util.fs();
+
+    fs.mkdir('/tmp/deep/path', {recursive:true}, function(error) {
+      expect(error).not.to.exist;
+      if(error) throw error;
+
+      fs.stat('/tmp/deep/path', function(error, stats) {
+        expect(error).not.to.exist;
+        expect(stats).to.exist;
+        expect(stats.type).to.equal('DIRECTORY');
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
This reworks `mkdir` to add support for passing `{recursive:true}` in order to create missing parent paths for a given child directory.  I've reworked the existing `mkdirp` code on the shell to accomplish this.  Also included are updates to the docs, and tests.

Our directory creation code doesn't yet take `mode` into account.  I've left a TODO comment in the code, and added support for it at the level of our `mkdir` function option handling.