### PR TITLE
Issue #436 - Implement basic fs.copyFile tests without flags

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -41,6 +41,7 @@ require('./spec/errors.spec');
 require('./spec/fs.shell.spec');
 require('./spec/fs.chmod.spec');
 require('./spec/fs.chown.spec');
+require('./spec/fs.copyFile.spec');
 
 // Filer.FileSystem.providers.*
 require('./spec/providers/providers.spec');

--- a/tests/spec/fs.copyFile.spec.js
+++ b/tests/spec/fs.copyFile.spec.js
@@ -1,4 +1,3 @@
-var Filer = require('../../src');
 var util = require('../lib/test-utils.js');
 var expect = require('chai').expect;
 
@@ -37,7 +36,7 @@ describe('fs.copyFile', function(){
 
   it('should copy file successfully', function(done) {
     var fs = util.fs();
-    var src = "This is a src file.";
+    var src = 'This is a src file.';
 
     fs.copyFile('/srcfile', '/destfile', function(error) {
       if(error) throw error;

--- a/tests/spec/fs.copyFile.spec.js
+++ b/tests/spec/fs.copyFile.spec.js
@@ -1,0 +1,53 @@
+var Filer = require('../../src');
+var util = require('../lib/test-utils.js');
+var expect = require('chai').expect;
+
+describe('fs.copyFile', function(){
+  beforeEach(function(done){
+    util.setup(function() {
+      var fs = util.fs();
+      fs.writeFile('/srcfile', 'This is a src file.', function(error){
+        if(error) throw error;
+        fs.writeFile('/destfile', 'This is a dest file.', function(error){
+          if(error) throw error;
+          done();
+        });
+      });
+    });
+  });
+  afterEach(util.cleanup);
+
+  it('should be a function', function() {
+    var fs = util.fs();
+    expect(fs.copyFile).to.be.a('function');
+  });
+
+  it('should return an error if the src path does not exist', function(done){
+    var fs = util.fs();
+    var src = null;
+    var dest = 'dest.txt';
+
+    fs.copyFile(src, dest, function(error){
+      expect(error).to.exist;
+      expect(error.code).to.equal('ENOENT');
+      done();
+    });
+   
+  });
+
+  it('should copy file successfully', function(done) {
+    var fs = util.fs();
+    var src = "This is a src file.";
+
+    fs.copyFile('/srcfile', '/destfile', function(error) {
+      if(error) throw error;
+
+      fs.readFile('/destfile', function(error, data){
+        expect(error).not.to.exist;
+        expect(data).to.equal(src);
+        done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
Closes #436 kind of, implements non-flag testing for future fs.copyFile implementation.

Checks whether it's a function, checks if error is thrown if source that is being copied doesn't exist, checks if file was copied successfully. 