### PR TITLE
Add test cases for fs.appendFile with explicit encoding and flag options

### DIFF
--- a/tests/spec/fs.appendFile.spec.js
+++ b/tests/spec/fs.appendFile.spec.js
@@ -50,6 +50,38 @@ describe('fs.appendFile', function() {
     });
   });
 
+  it('should append without error when explcitly entering encoding and flag options (default values)' , function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+    var more = ' Appended.';
+
+    fs.appendFile('/myfile', more , {encoding: 'utf8', flag: 'a'}, function(error) {
+      if(error) throw error;
+
+      fs.readFile('/myfile', { encoding: 'utf8' }, function(error, data) {
+        expect(error).not.to.exist;
+        expect(data).to.equal(contents + more);
+        done();
+      });
+    });
+  });
+
+  it('should append without error when specfifying flag option (default value)' , function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+    var more = ' Appended.';
+
+    fs.appendFile('/myfile', more , {flag: 'a'}, function(error) {
+      if(error) throw error;
+
+      fs.readFile('/myfile', { encoding: 'utf8' }, function(error, data) {
+        expect(error).not.to.exist;
+        expect(data).to.equal(contents + more);
+        done();
+      });
+    });
+  });
+
   it('should append a utf8 file with {encoding: "utf8"} option to appendFile', function(done) {
     var fs = util.fs();
     var contents = 'This is a file.';


### PR DESCRIPTION
Originally intending to add a test case for [fs.appendFile](https://nodejs.org/api/fs.html#fs_fs_appendfile_path_data_options_callback) to verify that selecting a flag manually does work as intended (#463), it seems that that test does in fact fail in some cases, but not in others. All calls to fs.appendFile here are tested with what should be their default values. I have instead added two tests instead of one, in order to illustrate where fs.appendFile seems to fail:

fs.appendFile(path, data[, options], callback)

New test 1 (passes) :   options ={ encoding: 'utf8', flag: 'a' }

New test 2 (fails): options = { flag: 'a'}

Similar existing test (passes): options = { encoding: 'utf8' } 

