### PR TITLE
fix #418 test for fsPromises.truncate(path[, len])

### DIFF
--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -192,3 +192,27 @@ describe('fs.truncate', function() {
     });
   });
 });
+
+describe('fsPromises.truncate', function () {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should error when length is negative', () => {
+
+    var fsPromises = util.fs().promises;
+    var contents = 'This is a file.';
+
+    fsPromises.writeFile('/myfile', contents)
+      .then(
+        error => {
+          if (error) throw error;
+        });
+
+    fsPromises.truncate('/myfile', -1)
+      .then(
+        error => {
+          expect(error).to.exist;
+          expect(error.code).to.equal('EINVAL');
+        });
+  });
+});


### PR DESCRIPTION
This fixes the issue #418.

There is now a test available for fsPromises.truncate(path[, len]) .

It checks if the length of the file is negative, and sends an error message.