### PR TITLE
Enforce newline at end of files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,10 @@
         "sourceType": "module"
     },
     "rules": {
+        "eol-last": [
+            "error",
+            "always"
+        ],
         "indent": [
             "error",
             2


### PR DESCRIPTION
Trailing newlines are a common idiom in programming, and enabling this rule will save reviewers nitpicking or overlooking missing trailing newlines.

ESLint also supports the `--fix` option to automate fixing some of the problems reported by this rule.

There are no current files in the codebase that require fixing to add trailing newlines as verified by `npm run lint`.