### PR TITLE
Add test for fsPromises.rmdir() when dir not empty and dir is a file, Fix Issue 474

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,14 +3278,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3300,20 +3298,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3430,8 +3425,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3443,7 +3437,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3458,7 +3451,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3466,14 +3458,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3492,7 +3482,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3573,8 +3562,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3586,7 +3574,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3708,7 +3695,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,12 +3278,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3298,17 +3300,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3425,7 +3430,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3437,6 +3443,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3451,6 +3458,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3458,12 +3466,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3482,6 +3492,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3562,7 +3573,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3574,6 +3586,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3695,6 +3708,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -102,24 +102,21 @@ describe('fs.rmdir', function() {
 
 describe('fs.promises.rmdir', function(){
   
-  beforeEach(function(done){
-    util.setup(function(){
-      var fs = util.fs();
-      fsPromises = fs.promises;
-      done();
-    })
-  });
+  beforeEach(util.setup);
   
   afterEach(util.cleanup);
 
   it('should return an error if the directory is not empty', function(done) {
 
-      fsPromises.mkdir('/tmp')
+    var fs = util.fs();
+    var fsPromises = fs.promises;
+
+    fsPromises.mkdir('/tmp')
       .then(fsPromises.mkdir('/tmp/mydir'))
       .then(fsPromises.rmdir('/'))
-      .catch(err => {
-        expect(error).to.exist;
-        expect(error.code).to.equal('ENOTEMPTY');
+      .catch(error => {
+        expect(error).to.eventually.exist;
+        expect(error.code).to.eventually.equal('ENOTEMPTY');
         done();
       });
 
@@ -127,15 +124,18 @@ describe('fs.promises.rmdir', function(){
  
   it('should return an error if the path is not a directory', function(done) {
 
-      fsPromises.mkdir('/tmp')
+    var fs = util.fs();
+    var fsPromises = fs.promises;
+
+    fsPromises.mkdir('/tmp')
       .then(fsPromises.open('/tmp/myfile','w'))
       .then(filehandle => {
         return filehandle.close();
       })
       .then(fsPromises.rmdir('/tmp/myfile'))
-      .catch(err => {
-        expect(err).to.exist;
-        expect(err.code).to.equal('ENOENT');
+      .catch(error => {
+        expect(error).to.eventually.exist;
+        expect(error.code).to.eventually.equal('ENOENT');
         done();
       });
     

--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -106,37 +106,32 @@ describe('fs.promises.rmdir', function(){
   
   afterEach(util.cleanup);
 
-  it('should return an error if the directory is not empty', function(done) {
+  it('should return an error if the directory is not empty', function() {
 
     var fs = util.fs();
     var fsPromises = fs.promises;
 
-    fsPromises.mkdir('/tmp')
-      .then(fsPromises.mkdir('/tmp/mydir'))
-      .then(fsPromises.rmdir('/'))
+    return fsPromises.mkdir('/tmp')
+      .then(() => fsPromises.mkdir('/tmp/mydir'))
+      .then(() => fsPromises.rmdir('/'))
       .catch(error => {
-        expect(error).to.eventually.exist;
-        expect(error.code).to.eventually.equal('ENOTEMPTY');
-        done();
+        expect(error).to.exist;
+        expect(error.code).to.equal('EBUSY');
       });
 
   });
  
-  it('should return an error if the path is not a directory', function(done) {
+  it('should return an error if the path is not a directory', function() {
 
     var fs = util.fs();
     var fsPromises = fs.promises;
 
-    fsPromises.mkdir('/tmp')
-      .then(fsPromises.open('/tmp/myfile','w'))
-      .then(filehandle => {
-        return filehandle.close();
-      })
-      .then(fsPromises.rmdir('/tmp/myfile'))
+    return fsPromises.mkdir('/tmp')
+      .then(() => fsPromises.writeFile('/tmp/myfile','Hello World'))
+      .then(() => fsPromises.rmdir('/tmp/myfile'))
       .catch(error => {
-        expect(error).to.eventually.exist;
-        expect(error.code).to.eventually.equal('ENOENT');
-        done();
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOTDIR');
       });
     
   });

--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -122,24 +122,23 @@ describe('fs.promises.rmdir', function(){
         expect(error.code).to.equal('ENOTEMPTY');
         done();
       });
+
   });
  
-  // it('should return an error if the path is not a directory', function(done) {
+  it('should return an error if the path is not a directory', function(done) {
 
-  //   fs.mkdir('/tmp', function(error) {
-  //     if(error) throw error;
-  //     fs.open('/tmp/myfile', 'w', function(error, fd) {
-  //       if(error) throw error;
-  //       fs.close(fd, function(error) {
-  //         if(error) throw error;
-  //         fs.rmdir('/tmp/myfile', function(error) {
-  //           expect(error).to.exist;
-  //           expect(error.code).to.equal('ENOTDIR');
-  //           done();
-  //         });
-  //       });
-  //     });
-  //   });
-  // });
-
+      fsPromises.mkdir('/tmp')
+      .then(fsPromises.open('/tmp/myfile','w'))
+      .then(filehandle => {
+        return filehandle.close();
+      })
+      .then(fsPromises.rmdir('/tmp/myfile'))
+      .catch(err => {
+        expect(err).to.exist;
+        expect(err.code).to.equal('ENOENT');
+        done();
+      });
+    
+  });
+    
 });

--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -46,7 +46,6 @@ describe('fs.rmdir', function() {
     });
   });
 
-
   it('should return an error if the path is not a directory', function(done) {
     var fs = util.fs();
 
@@ -101,13 +100,10 @@ describe('fs.rmdir', function() {
 });
 
 describe('fs.promises.rmdir', function(){
-  
   beforeEach(util.setup);
-  
   afterEach(util.cleanup);
 
   it('should return an error if the directory is not empty', function() {
-
     var fs = util.fs();
     var fsPromises = fs.promises;
 
@@ -118,11 +114,9 @@ describe('fs.promises.rmdir', function(){
         expect(error).to.exist;
         expect(error.code).to.equal('EBUSY');
       });
-
   });
  
   it('should return an error if the path is not a directory', function() {
-
     var fs = util.fs();
     var fsPromises = fs.promises;
 
@@ -133,7 +127,5 @@ describe('fs.promises.rmdir', function(){
         expect(error).to.exist;
         expect(error.code).to.equal('ENOTDIR');
       });
-    
   });
-    
 });

--- a/tests/spec/fs.rmdir.spec.js
+++ b/tests/spec/fs.rmdir.spec.js
@@ -46,6 +46,7 @@ describe('fs.rmdir', function() {
     });
   });
 
+
   it('should return an error if the path is not a directory', function(done) {
     var fs = util.fs();
 
@@ -97,4 +98,48 @@ describe('fs.rmdir', function() {
       });
     });
   });
+});
+
+describe('fs.promises.rmdir', function(){
+  
+  beforeEach(function(done){
+    util.setup(function(){
+      var fs = util.fs();
+      fsPromises = fs.promises;
+      done();
+    })
+  });
+  
+  afterEach(util.cleanup);
+
+  it('should return an error if the directory is not empty', function(done) {
+
+      fsPromises.mkdir('/tmp')
+      .then(fsPromises.mkdir('/tmp/mydir'))
+      .then(fsPromises.rmdir('/'))
+      .catch(err => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOTEMPTY');
+        done();
+      });
+  });
+ 
+  // it('should return an error if the path is not a directory', function(done) {
+
+  //   fs.mkdir('/tmp', function(error) {
+  //     if(error) throw error;
+  //     fs.open('/tmp/myfile', 'w', function(error, fd) {
+  //       if(error) throw error;
+  //       fs.close(fd, function(error) {
+  //         if(error) throw error;
+  //         fs.rmdir('/tmp/myfile', function(error) {
+  //           expect(error).to.exist;
+  //           expect(error.code).to.equal('ENOTDIR');
+  //           done();
+  //         });
+  //       });
+  //     });
+  //   });
+  // });
+
 });


### PR DESCRIPTION
I added two new tests for fsPromises.rmdir() [when the directory is not empty](https://github.com/thanhcng/filer/blob/a765d5436002788f20f5ccbfe3c9894e7363f4f0/tests/spec/fs.rmdir.spec.js#L109) and [when the directory is a file instead](https://github.com/thanhcng/filer/blob/a765d5436002788f20f5ccbfe3c9894e7363f4f0/tests/spec/fs.rmdir.spec.js#L124). Fix #474 