### PR TITLE
Fixed issue#480 using promises to test fs.truncate when path does not exist

### DIFF
--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -192,3 +192,22 @@ describe('fs.truncate', function() {
     });
   });
 });
+
+
+describe('fsPromises.truncate', function () {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+  it('should error when path does not exist (with promises)', (done) => {
+    var fsPromises = util.fs().promises;
+
+    fsPromises.truncate('/NonExistingPath', 0)
+      .then(result => expect(result).not.to.exist)
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOENT');
+      })
+      .then(() => done());
+  });
+});
+
+

--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -197,17 +197,13 @@ describe('fs.truncate', function() {
 describe('fsPromises.truncate', function () {
   beforeEach(util.setup);
   afterEach(util.cleanup);
-  it('should error when path does not exist (with promises)', (done) => {
+  it('should error when path does not exist (with promises)', () => {
     var fsPromises = util.fs().promises;
 
-    fsPromises.truncate('/NonExistingPath', 0)
-      .then(result => expect(result).not.to.exist)
+    return fsPromises.truncate('/NonExistingPath', 0)
       .catch(error => {
         expect(error).to.exist;
         expect(error.code).to.equal('ENOENT');
-      })
-      .then(() => done());
+      });
   });
 });
-
-


### PR DESCRIPTION
Fixes #480  - Add a test for truncate when path does not exist using promises.

I attempted to add a test for when fs.truncate is being passed a path/file that does not exist.
This was all done using promises.