### PR TITLE
Fix issue #475 - Add test for fs.exits() when resulting path of a symbolic link is not found

### DIFF
--- a/tests/spec/fs.exists.spec.js
+++ b/tests/spec/fs.exists.spec.js
@@ -56,4 +56,28 @@ describe('fs.exists', function() {
       });
     });
   });
+  it('should follow symbolic links and return false if for the resulting path does not exist', function(done) {
+    var fs = util.fs();
+
+    fs.open('/myfile', 'w', function(error, fd) {
+      if(error) throw error;
+
+      fs.close(fd, function(error) {
+        if(error) throw error;
+
+        fs.symlink('/myfile', '/myfilelink', function(error) {
+          if(error) throw error;
+        
+          fs.unlink('/myfile', function(err) {
+            if(err) throw err;
+          
+            fs.exists('/myfilelink', function(result) {
+              expect(result).to.be.false;
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
 });

--- a/tests/spec/fs.exists.spec.js
+++ b/tests/spec/fs.exists.spec.js
@@ -56,6 +56,7 @@ describe('fs.exists', function() {
       });
     });
   });
+  
   it('should follow symbolic links and return false if for the resulting path does not exist', function(done) {
     var fs = util.fs();
 


### PR DESCRIPTION
Fixes #475 - Add test for fs.exists() when it follows symbolic link and can't find directory.

It tests by creating a symbolic link for a path and then deleting the path. The test should return false.

Passed all the tests