### PR TITLE
Issue497 Add test for fs.chmod when the path is invalid

### DIFF
--- a/tests/spec/fs.chmod.spec.js
+++ b/tests/spec/fs.chmod.spec.js
@@ -39,6 +39,17 @@ describe('fs.chmod, fs.fchmod', function() {
     });
   });
 
+  it('should error whenp path is invalid', function(done){
+    var fs = util.fs();
+
+      fs.chmod("/invalid_file", 0o444, function(err) {
+        expect(err).to.exist;
+        expect(err.code).to.equal('EINVAL');
+        done();
+      });
+    });
+  });
+
   it('should allow for updating mode of a given file', function(done) {
     var fs = util.fs();
 

--- a/tests/spec/fs.chmod.spec.js
+++ b/tests/spec/fs.chmod.spec.js
@@ -39,15 +39,14 @@ describe('fs.chmod, fs.fchmod', function() {
     });
   });
 
-  it('should error whenp path is invalid', function(done){
+  it('should be an error when the path is invalid', function(done){
     var fs = util.fs();
-
-      fs.chmod("/invalid_file", 0o444, function(err) {
-        expect(err).to.exist;
-        expect(err.code).to.equal('EINVAL');
-        done();
-      });
+    fs.chmod('/invalid_path', 0o444, function(err){
+      expect(err).to.exist;
+      expect(err.code).to.equal('ENOENT');
+      done();
     });
+
   });
 
   it('should allow for updating mode of a given file', function(done) {


### PR DESCRIPTION
Added a function to test the [fs.chomd](https://github.com/filerjs/filer/blob/master/tests/spec/fs.chmod.spec.js), when people passed the invalid path as the argument, they will get the error code 'ENOENT'. All tests are passed.