### PR TITLE
Fixes #499: Update functionality for fs.truncate

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -39,6 +39,7 @@ var SuperNode = require('../super-node.js');
 var Node = require('../node.js');
 var Stats = require('../stats.js');
 var Buffer = require('../buffer.js');
+const { validateInteger } = require('../shared.js');
 
 /**
  * Update node times. Only passed times are modified (undefined times are ignored)
@@ -1249,8 +1250,11 @@ function truncate_file(context, path, length, callback) {
       if(!fileData) {
         return callback(new Errors.EIO('Expected Buffer'));
       }
-      if (!Number.isInteger(length)) {
-        return callback(new Errors.EINVAL('length must be a number'));
+      try {
+        validateInteger(length, 'len');
+      }
+      catch (error) {
+        return callback(error);
       }
       var data = new Buffer(length);
       data.fill(0);

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1249,6 +1249,9 @@ function truncate_file(context, path, length, callback) {
       if(!fileData) {
         return callback(new Errors.EIO('Expected Buffer'));
       }
+      if (!Number.isInteger(length)) {
+        return callback(new Errors.EINVAL('length must be a number'));
+      }
       var data = new Buffer(length);
       data.fill(0);
       if(fileData) {

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,3 +1,5 @@
+var Errors = require('./errors.js');
+
 function guid() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
@@ -19,8 +21,24 @@ function u8toArray(u8) {
   return array;
 }
 
+function validateInteger(value, name) {
+  let err;
+
+  if (typeof value !== 'number')
+    err = new Errors.EINVAL(name, 'number', value);
+
+  if (err) {
+    Error.captureStackTrace(err, validateInteger);
+    throw err;
+  }
+
+  return value;
+}
+
+
 module.exports = {
   guid: guid,
   u8toArray: u8toArray,
-  nop: nop
+  nop: nop,
+  validateInteger: validateInteger,
 };

--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -10,6 +10,21 @@ describe('fs.truncate', function() {
     expect(fs.truncate).to.be.a('function');
   });
 
+  it('should error when length is not an integer', function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+
+    fs.writeFile('/myfile', contents, function(error) {
+      if(error) throw error;
+
+      fs.truncate('/myfile', 'notAnInteger', function(error) {
+        expect(error).to.exist;
+        expect(error.code).to.equal('EINVAL');
+        done();
+      });
+    });
+  });
+
   it('should error when length is negative', function(done) {
     var fs = util.fs();
     var contents = 'This is a file.';


### PR DESCRIPTION
This change to fs.truncate()'s functionality throws an error when the
length to truncate by is a non-numeric string.