### PR TITLE
Fix: #534 Added tests for Symlink using Promises API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Want to join the fun? We'd love to have you! See [CONTRIBUTING](https://github.c
 
 Filer can be obtained in a number of ways:
 
-
 1. npm - `npm install filer`
 2. bower - `bower install filer`
 3. download pre-built versions: [filer.js](https://raw.github.com/filerjs/filer/develop/dist/filer.js), [filer.min.js](https://raw.github.com/filerjs/filer/develop/dist/filer.min.js)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Want to join the fun? We'd love to have you! See [CONTRIBUTING](https://github.c
 
 Filer can be obtained in a number of ways:
 
+
 1. npm - `npm install filer`
 2. bower - `bower install filer`
 3. download pre-built versions: [filer.js](https://raw.github.com/filerjs/filer/develop/dist/filer.js), [filer.min.js](https://raw.github.com/filerjs/filer/develop/dist/filer.min.js)

--- a/tests/spec/fs.symlink.spec.js
+++ b/tests/spec/fs.symlink.spec.js
@@ -43,6 +43,7 @@ describe('fs.symlink', function() {
       });
     });
   });
+  /** Tests for fsPromises API */
   describe('fsPromises.symlink', function () {
     it('should return an error if destination path does not exist', function () {
       var fsPromises = util.fs().promises;
@@ -51,7 +52,7 @@ describe('fs.symlink', function() {
           expect(error).to.exist;
           expect(error.code).to.equal('ENOENT');
         });
-    });
+    
     it('should return an error if source path does not exist', function () {
       var fsPromises = util.fs().promises;
       return fsPromises.symlink('/tmp/myLink', '/myLink')
@@ -77,11 +78,10 @@ describe('fs.symlink', function() {
             });
         });
     });
+      
     it('Promise should create a symlink of type FILE when file provided', function () {
       var fsPromises = util.fs().promises;
-      var fs = util.fs();
-      fs.open('/myFile', 'w+', function (error) {
-        if (error) throw error;
+      fsPromises.open('/myFile', 'w+').catch((error) => {
         expect(error).not.to.exist;
       });
       return fsPromises.symlink('/myFile', '/myFileLink')
@@ -97,6 +97,7 @@ describe('fs.symlink', function() {
             });
         });
     });
+      
     it('Promise should return an error if the destination path already exists', function () {
       var fsPromises = util.fs().promises;
 

--- a/tests/spec/fs.symlink.spec.js
+++ b/tests/spec/fs.symlink.spec.js
@@ -1,42 +1,42 @@
 var util = require('../lib/test-utils.js');
 var expect = require('chai').expect;
 
-describe('fs.symlink', function() {
+describe('fs.symlink', function () {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
-  it('should be a function', function() {
+  it('should be a function', function () {
     var fs = util.fs();
     expect(fs.symlink).to.be.a('function');
   });
 
-  it('should return an error if part of the parent destination path does not exist', function(done) {
+  it('should return an error if part of the parent destination path does not exist', function (done) {
     var fs = util.fs();
 
-    fs.symlink('/', '/tmp/mydir', function(error) {
+    fs.symlink('/', '/tmp/mydir', function (error) {
       expect(error).to.exist;
       expect(error.code).to.equal('ENOENT');
       done();
     });
   });
 
-  it('should return an error if the destination path already exists', function(done) {
+  it('should return an error if the destination path already exists', function (done) {
     var fs = util.fs();
 
-    fs.symlink('/tmp', '/', function(error) {
+    fs.symlink('/tmp', '/', function (error) {
       expect(error).to.exist;
       expect(error.code).to.equal('EEXIST');
       done();
     });
   });
 
-  it('should create a symlink', function(done) {
+  it('should create a symlink', function (done) {
     var fs = util.fs();
 
-    fs.symlink('/', '/myfile', function(error) {
+    fs.symlink('/', '/myfile', function (error) {
       expect(error).not.to.exist;
 
-      fs.stat('/myfile', function(err, stats) {
+      fs.stat('/myfile', function (err, stats) {
         expect(error).not.to.exist;
         expect(stats.type).to.equal('DIRECTORY');
         done();
@@ -52,7 +52,8 @@ describe('fs.symlink', function() {
           expect(error).to.exist;
           expect(error.code).to.equal('ENOENT');
         });
-    
+    });
+
     it('should return an error if source path does not exist', function () {
       var fsPromises = util.fs().promises;
       return fsPromises.symlink('/tmp/myLink', '/myLink')
@@ -61,7 +62,6 @@ describe('fs.symlink', function() {
           expect(error.code).to.equal('ENOENT');
         });
     });
-
 
     it('Promise should create a symlink of type DIRECTORY when directory provided', function () {
       var fsPromises = util.fs().promises;
@@ -78,7 +78,7 @@ describe('fs.symlink', function() {
             });
         });
     });
-      
+
     it('Promise should create a symlink of type FILE when file provided', function () {
       var fsPromises = util.fs().promises;
       fsPromises.open('/myFile', 'w+').catch((error) => {
@@ -97,7 +97,7 @@ describe('fs.symlink', function() {
             });
         });
     });
-      
+
     it('Promise should return an error if the destination path already exists', function () {
       var fsPromises = util.fs().promises;
 
@@ -107,6 +107,6 @@ describe('fs.symlink', function() {
           expect(error.code).to.equal('EEXIST');
         });
     });
+    
   });
-
 });

--- a/tests/spec/fs.symlink.spec.js
+++ b/tests/spec/fs.symlink.spec.js
@@ -43,4 +43,69 @@ describe('fs.symlink', function() {
       });
     });
   });
+  describe('fsPromises.symlink', function () {
+    it('should return an error if destination path does not exist', function () {
+      var fsPromises = util.fs().promises;
+      return fsPromises.symlink('/', '/tmp/link')
+        .catch(error => {
+          expect(error).to.exist;
+          expect(error.code).to.equal('ENOENT');
+        });
+    });
+    it('should return an error if source path does not exist', function () {
+      var fsPromises = util.fs().promises;
+      return fsPromises.symlink('/tmp/myLink', '/myLink')
+        .catch(error => {
+          expect(error).to.exist;
+          expect(error.code).to.equal('ENOENT');
+        });
+    });
+
+
+    it('Promise should create a symlink of type DIRECTORY when directory provided', function () {
+      var fsPromises = util.fs().promises;
+      return fsPromises.symlink('/', '/myDirLink')
+        .then(() => {
+          return fsPromises.stat('/myDirLink')
+            .then(stats => {
+              expect(stats).to.exist;
+              expect(stats.type).to.equal('DIRECTORY');
+            })
+            .catch(error => {
+              expect(error).not.to.exist;
+              expect(error.code).to.equal('ENOENT');
+            });
+        });
+    });
+    it('Promise should create a symlink of type FILE when file provided', function () {
+      var fsPromises = util.fs().promises;
+      var fs = util.fs();
+      fs.open('/myFile', 'w+', function (error) {
+        if (error) throw error;
+        expect(error).not.to.exist;
+      });
+      return fsPromises.symlink('/myFile', '/myFileLink')
+        .then(() => {
+          return fsPromises.stat('/myFileLink')
+            .then(stats => {
+              expect(stats).to.exist;
+              expect(stats.type).to.equal('FILE');
+            })
+            .catch(error => {
+              expect(error).not.to.exist;
+              expect(error.code).to.equal('ENOENT');
+            });
+        });
+    });
+    it('Promise should return an error if the destination path already exists', function () {
+      var fsPromises = util.fs().promises;
+
+      return fsPromises.symlink('/tmp', '/')
+        .catch(error => {
+          expect(error).to.exist;
+          expect(error.code).to.equal('EEXIST');
+        });
+    });
+  });
+
 });


### PR DESCRIPTION
Added tests for Symlink using promises workflow (Should expect same results as fs.Symlink with callback)
Not sure if these should be included in their own file because they are related to promises or if all symlink tests belong in the fs.symlink.spec.js file
Passed Tests