### PR TITLE
Fix issue #394: Added tests for mkdtemp method

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ var fs = new Filer.FileSystem();
 * [fs.mknod(path, mode, callback)](#mknod)
 * [fs.rmdir(path, callback)](#rmdir)
 * [fs.mkdir(path, [mode], callback)](#mkdir)
+* [fs.mkdtemp(path, [mode], callback)](#mkdtemp)
 * [fs.readdir(path, callback)](#readdir)
 * [fs.close(fd, callback)](#close)
 * [fs.open(path, flags, [mode], callback)](#open)
@@ -671,6 +672,30 @@ fs.mkdir('/home', function(err) {
     // directory /home/carl now exists
   });
 });
+```
+
+#### fs.mkdtemp(prefix, options, callback)<a name="mkdtemp"></a>
+
+
+Makes a temporary directory with prefix supplied in `path` argument. Method will append the six randomly selected characters directly to the prefix.
+
+Asynchronous. Callback gets `(error, path)`, where path is a path to created directory.
+
+NOTE: Filer allows for, but ignores the optional `options` argument used in node.js.
+
+Example:
+
+```javascript
+// Create tmp directory with prefix foo
+fs.mkdtemp("foo-", function (error, path) {
+    //A new folder foo-xxxxxx will be created. Path contains a path to created folder.    
+});
+
+fs.mkdtemp("/myDir/tmp", function (error, path) {
+    //Will create a new folder tmpxxxxxx inside myDir directory. 
+    //Will throw error if myDir does not exist    
+});
+
 ```
 
 #### fs.readdir(path, callback)<a name="readdir"></a>

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1681,7 +1681,7 @@ function mkdir(fs, context, path, mode, callback) {
 function mkdtemp(fs, context, prefix, options, callback) { 
   callback = arguments[arguments.length - 1];
 
-  // this function is ised to generate a random character set to append 
+  // this function is used to generate a random character set to append 
   // to tmp dir name to make sure it is unique
   function generateRandom() {
     return 'xxxxxx'.replace(/[xy]/g, function(c) {

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1687,19 +1687,19 @@ function mkdtemp(fs, context, prefix, options, callback) {
     return 'xxxxxx'.replace(/[xy]/g, function(c) {
       var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
       return v.toString(16);
-    })
+    });
   }
   if (prefix) {
-    var path = "/"+prefix+generateRandom();
+    var path = '/'+prefix+generateRandom();
     make_directory(context, path, function(error) {
       if (error) {
-        callback(error, path)
+        callback(error, path);
       } else {
         callback(null, path);
       }
     });
   } else {
-    callback(new Error('filename prefix is required'), prefix)
+    callback(new Error('filename prefix is required'), prefix);
   }  
 }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1699,7 +1699,7 @@ function mkdtemp(fs, context, prefix, options, callback) {
       }
     });
   } else {
-    callback(new Error('filename prefix is required'), path)
+    callback(new Error('filename prefix is required'), prefix)
   }  
 }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1678,7 +1678,7 @@ function mkdir(fs, context, path, mode, callback) {
   make_directory(context, path, callback);
 }
 
-function mkdtemp(fs, context, prefix, callback) { 
+function mkdtemp(fs, context, prefix, options, callback) { 
   callback = arguments[arguments.length - 1];
 
   // this function is ised to generate a random character set to append 
@@ -1689,42 +1689,18 @@ function mkdtemp(fs, context, prefix, callback) {
       return v.toString(16);
     })
   }
-
-  var tmpDir = "/tmp";      //tmp dir in root
-  var tmpDirExists = false;   //flag to check if already created
-  
-  if (!prefix) {
-    prefix = generateRandom(); //if user did not specify prefix
-  }
-  prefix = prefix + "-" + generateRandom();
-  var path = Path.join(tmpDir, prefix); //path to a new tmp dir  
-  
-  // check if root temporary directory '/tmp' already exists
-  fs.stat(tmpDir, function(error, stats) {
-    if (!error) {
-      if (stats.isDirectory()) {
-        tmpDirExists = true;
-      }
-    } 
-  });
-
-  //try to create /tmp in root
-  if (!tmpDirExists) {
-    make_directory(context, tmpDir, function(error) {
+  if (prefix) {
+    var path = "/"+prefix+generateRandom();
+    make_directory(context, path, function(error) {
       if (error) {
         callback(error, path)
-      } else {        
-         //create new temp dir in /tmp
-          make_directory(context, path, function(error) {
-            if (error) {
-              callback(error, path)
-            } else {
-              callback(null, path);
-            }
-          });
+      } else {
+        callback(null, path);
       }
     });
-  }   
+  } else {
+    callback(new Error('filename prefix is required'), path)
+  }  
 }
 
 function rmdir(fs, context, path, callback) {
@@ -2433,6 +2409,7 @@ module.exports = {
   close: close,
   mknod: mknod,
   mkdir: mkdir,
+  mkdtemp: mkdtemp,
   rmdir: rmdir,
   unlink: unlink,
   stat: stat,

--- a/src/filesystem/interface.js
+++ b/src/filesystem/interface.js
@@ -276,6 +276,7 @@ function FileSystem(options, callback) {
     'close',
     'mknod',
     'mkdir',
+    'mkdtemp',
     'rmdir',
     'stat',
     'fstat',

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,6 +14,7 @@ require('./spec/fs.lstat.spec');
 require('./spec/fs.exists.spec');
 require('./spec/fs.mknod.spec');
 require('./spec/fs.mkdir.spec');
+require('./spec/fs.mkdtemp.spec');
 require('./spec/fs.readdir.spec');
 require('./spec/fs.rmdir.spec');
 require('./spec/fs.open.spec');

--- a/tests/spec/fs.mkdtemp.spec.js
+++ b/tests/spec/fs.mkdtemp.spec.js
@@ -10,7 +10,7 @@ describe('fs.mkdtemp', function() {
     expect(fs.mkdtemp).to.be.a('function');
   });
 
-  it('should craete temp dir with specified prefix', function(done) {
+  it('should create temp dir with specified prefix', function(done) {
     var fs = util.fs();
     fs.mkdtemp('foo', function(error, path) {
       expect(error).not.to.exist;
@@ -18,7 +18,8 @@ describe('fs.mkdtemp', function() {
       done();
     });
   });
-  it('should craete temp dir inside existing directory', function(done) {
+
+  it('should create temp dir inside existing directory', function(done) {
     var fs = util.fs();
     fs.mkdir('/myDir', (error) => {
       expect(error).not.to.exist;
@@ -28,7 +29,6 @@ describe('fs.mkdtemp', function() {
         done();
       });
     });
-
   });
 
   it('should not create temp dir without prefix', function(done) {
@@ -39,6 +39,7 @@ describe('fs.mkdtemp', function() {
       done();
     });
   });
+  
   it('should not create temp dir inside non existing dir', function(done) {
     var fs = util.fs();
     fs.mkdtemp('/doesNotExists/foo', function(error, path) {

--- a/tests/spec/fs.mkdtemp.spec.js
+++ b/tests/spec/fs.mkdtemp.spec.js
@@ -1,0 +1,51 @@
+var util = require('../lib/test-utils.js');
+var expect = require('chai').expect;
+
+describe('fs.mkdtemp', function() {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
+
+  it('should be a function', function() {
+    var fs = util.fs();
+    expect(fs.mkdtemp).to.be.a('function');
+  });
+
+  it('should craete temp dir with specified prefix', function(done) {
+    var fs = util.fs();
+    fs.mkdtemp('foo', function(error, path) {
+      expect(error).not.to.exist;
+      expect(path).to.match(/foo.{6}/);
+      done();
+    });
+  });
+  it('should craete temp dir inside existing directory', function(done) {
+    var fs = util.fs();
+    fs.mkdir('/myDir', (error) => {
+      expect(error).not.to.exist;
+      fs.mkdtemp('/myDir/foo', function(error, path) {
+        expect(error).not.to.exist;
+        expect(path).to.match(/foo.{6}/);
+        done();
+      });
+    });
+
+  });
+
+  it('should not create temp dir without prefix', function(done) {
+    var fs = util.fs();
+    fs.mkdtemp('', function(error, path) {
+      expect(error).to.exist;
+      expect(path).to.be.equal('');
+      done();
+    });
+  });
+  it('should not create temp dir inside non existing dir', function(done) {
+    var fs = util.fs();
+    fs.mkdtemp('/doesNotExists/foo', function(error, path) {
+      expect(error).to.exist;
+      expect(error.code).to.be.equal('ENOENT');
+      expect(path).to.exist;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Tests for mkdtemp method discussed in issue #394, #441 and [pr 433](https://github.com/filerjs/filer/pull/443) created): 
- tests that mkdtemp is a function
- tests that tmp dir was created for given prefix
- tests that tmp dir was created for given prefix inside existing parent directory
- tests that an error is thrown if tmp directory is requested to be created in non-existing directory