### PR TITLE
Fixed #544 - Test for fs.truncate() << test, when file does not exists

### DIFF
--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -65,6 +65,19 @@ describe('fs.truncate', function() {
       });
     });
   });
+  
+ 
+   it('should error when file does not exist (with promises)' => {
+   var fsPromises = util.fs().promises;
+   return
+   fsPromises.truncate('/NonExistingFile' , 0)
+                  .catch(error => {
+    expect(error).to.exixts;
+    expect(error.code).to.equal('ENOENT');
+   })
+   .then(() => done());
+});
+});
 
   it('should pad a file with zeros when the length is greater than the file size', function(done) {
     var fs = util.fs();

--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -4,20 +4,6 @@ var expect = require('chai').expect;
 describe('fs.truncate', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
-  
-   it('should error when file does not exist (with promises)' , ()=> {
-   var fsPromises = util.fs().promises;
-
-   return fsPromises.truncate('/NonExistingPath' , 0)
-     .catch(error => {
-         expect(error).to.exixts;
-         expect(error.code).to.equal('ENOENT');
-      })
-      .then(() => done());
-      });
-    });
-  });
-});
 
 
   it('should be a function', function() {
@@ -239,4 +225,15 @@ describe('fs.truncate', function() {
       });
     });
   });
+});
+
+it('should error when file does not exist' , ()=> {
+  var fsPromises = util.fs().promises;
+
+  return fsPromises.truncate('/NonExistingPath' , 0)
+    .catch(error => {
+      expect(error).to.exixts;
+      expect(error.code).to.equal('ENOENT');
+    });
+  
 });

--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -4,6 +4,21 @@ var expect = require('chai').expect;
 describe('fs.truncate', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
+  
+   it('should error when file does not exist (with promises)' , ()=> {
+   var fsPromises = util.fs().promises;
+
+   return fsPromises.truncate('/NonExistingPath' , 0)
+     .catch(error => {
+         expect(error).to.exixts;
+         expect(error.code).to.equal('ENOENT');
+      })
+      .then(() => done());
+      });
+    });
+  });
+});
+
 
   it('should be a function', function() {
     var fs = util.fs();
@@ -67,18 +82,7 @@ describe('fs.truncate', function() {
   });
   
  
-   it('should error when file does not exist (with promises)' => {
-   var fsPromises = util.fs().promises;
-   return
-   fsPromises.truncate('/NonExistingFile' , 0)
-                  .catch(error => {
-    expect(error).to.exixts;
-    expect(error.code).to.equal('ENOENT');
-   })
-   .then(() => done());
-});
-});
-
+   
   it('should pad a file with zeros when the length is greater than the file size', function(done) {
     var fs = util.fs();
     var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -229,16 +229,13 @@ describe('fs.truncate', function() {
 
 describe('fsPromises.truncate', function () {
   beforeEach(util.setup);
-  afterEach(util.cleanup);
-  
-  it('should error when file does not exist (with promises)' , ()=> {
+  afterEach(util.cleanup); 
+  it('should error when file does not exist (with promises)' , () => {
     var fsPromises = util.fs().promises;
-
-    return fsPromises.truncate('/NonExistingPath' , 0)
+    return fsPromises.truncate('/NonExistingPath', 0)
       .catch(error => {
         expect(error).to.exist;
         expect(error.code).to.equal('ENOENT');
       });
   });
 });
-

--- a/tests/spec/fs.truncate.spec.js
+++ b/tests/spec/fs.truncate.spec.js
@@ -227,13 +227,18 @@ describe('fs.truncate', function() {
   });
 });
 
-it('should error when file does not exist' , ()=> {
-  var fsPromises = util.fs().promises;
-
-  return fsPromises.truncate('/NonExistingPath' , 0)
-    .catch(error => {
-      expect(error).to.exixts;
-      expect(error.code).to.equal('ENOENT');
-    });
+describe('fsPromises.truncate', function () {
+  beforeEach(util.setup);
+  afterEach(util.cleanup);
   
+  it('should error when file does not exist (with promises)' , ()=> {
+    var fsPromises = util.fs().promises;
+
+    return fsPromises.truncate('/NonExistingPath' , 0)
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOENT');
+      });
+  });
 });
+


### PR DESCRIPTION
Added test to fs.truncate() that checks if a file does not exists. 
I have used promises to test this out. 
