### PR TITLE
Fix appendFile bug shown to fail in PR-494

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1870,12 +1870,17 @@ function appendFile(fs, context, path, data, options, callback) {
   if(!flags) {
     return callback(new Errors.EINVAL('flags is not valid', path));
   }
+  
+  if (typeof options === 'object' && options.encoding === undefined ) {
+    options.encoding = 'utf8';
+  }
 
   data = data || '';
   if(typeof data === 'number') {
     data = '' + data;
   }
-  if(typeof data === 'string' && (options.encoding === null || options.encoding === 'utf8')) {
+  
+  if(typeof data === 'string' && options.encoding === 'utf8') {
     data = Encoding.encode(data);
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1875,7 +1875,7 @@ function appendFile(fs, context, path, data, options, callback) {
   if(typeof data === 'number') {
     data = '' + data;
   }
-  if(typeof data === 'string' && (options.encoding == null || options.encoding === 'utf8')) {
+  if(typeof data === 'string' && (options.encoding === null || options.encoding === 'utf8')) {
     data = Encoding.encode(data);
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1874,6 +1874,18 @@ function appendFile(fs, context, path, data, options, callback) {
   if (typeof options === 'object' && options.encoding === undefined ) {
     options.encoding = 'utf8';
   }
+  
+  if typeof (options ==== 'object') {
+    if (options.encoding === undefined) {
+      options.encoding = 'utf8';
+    }
+    if (options.mode === undefined) {
+      options.mode = 0o666;
+    }
+    if (options.flag === undefined) {
+      options.flag = 'a';
+    }
+  }
 
   data = data || '';
   if(typeof data === 'number') {

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1871,7 +1871,7 @@ function appendFile(fs, context, path, data, options, callback) {
     return callback(new Errors.EINVAL('flags is not valid', path));
   }
   
-  if (typeof options ==== 'object') {
+  if (typeof options === 'object') {
     if (options.encoding === undefined) {
       options.encoding = 'utf8';
     }

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1871,10 +1871,6 @@ function appendFile(fs, context, path, data, options, callback) {
     return callback(new Errors.EINVAL('flags is not valid', path));
   }
   
-  if (typeof options === 'object' && options.encoding === undefined ) {
-    options.encoding = 'utf8';
-  }
-  
   if typeof (options ==== 'object') {
     if (options.encoding === undefined) {
       options.encoding = 'utf8';

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1871,14 +1871,14 @@ function appendFile(fs, context, path, data, options, callback) {
     return callback(new Errors.EINVAL('flags is not valid', path));
   }
   
-  if typeof (options ==== 'object') {
+  if (typeof options ==== 'object') {
     if (options.encoding === undefined) {
       options.encoding = 'utf8';
     }
-    if (options.mode === undefined) {
+    if (typeof options.mode === undefined) {
       options.mode = 0o666;
     }
-    if (options.flag === undefined) {
+    if (typeof options.flag === undefined) {
       options.flag = 'a';
     }
   }

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1875,7 +1875,7 @@ function appendFile(fs, context, path, data, options, callback) {
   if(typeof data === 'number') {
     data = '' + data;
   }
-  if(typeof data === 'string' && options.encoding === 'utf8') {
+  if(typeof data === 'string' && (options.encoding == null || options.encoding === 'utf8')) {
     data = Encoding.encode(data);
   }
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1875,10 +1875,10 @@ function appendFile(fs, context, path, data, options, callback) {
     if (!options.encoding) {
       options.encoding = 'utf8';
     }
-    if (typeof options.mode === undefined) {
+    if (!options.mode) {
       options.mode = 0o666;
     }
-    if (typeof options.flag === undefined) {
+    if (!options.flag) {
       options.flag = 'a';
     }
   }

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1872,7 +1872,7 @@ function appendFile(fs, context, path, data, options, callback) {
   }
   
   if (typeof options === 'object') {
-    if (options.encoding === undefined) {
+    if (!options.encoding) {
       options.encoding = 'utf8';
     }
     if (typeof options.mode === undefined) {

--- a/tests/spec/fs.appendFile.spec.js
+++ b/tests/spec/fs.appendFile.spec.js
@@ -65,6 +65,38 @@ describe('fs.appendFile', function() {
       });
     });
   });
+    
+  it('should append without error when explcitly entering encoding and flag options (default values)' , function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+    var more = ' Appended.';
+
+    fs.appendFile('/myfile', more , {encoding: 'utf8', flag: 'a'}, function(error) {
+      if(error) throw error;
+
+      fs.readFile('/myfile', { encoding: 'utf8' }, function(error, data) {
+        expect(error).not.to.exist;
+        expect(data).to.equal(contents + more);
+        done();
+      });
+    });
+  });
+
+  it('should append without error when specfifying flag option (default value)' , function(done) {
+    var fs = util.fs();
+    var contents = 'This is a file.';
+    var more = ' Appended.';
+
+    fs.appendFile('/myfile', more , {flag: 'a'}, function(error) {
+      if(error) throw error;
+
+      fs.readFile('/myfile', { encoding: 'utf8' }, function(error, data) {
+        expect(error).not.to.exist;
+        expect(data).to.equal(contents + more);
+        done();
+      });
+    });
+  });
 
   it('should append a binary file', function(done) {
     var fs = util.fs();


### PR DESCRIPTION
As seen in PR #494, the current implementation of appendFile fails when passing a parameter that looks like { flag: 'a' } (which should succeed, since 'a' is a default value). I have included a fix and the accompanying test to verify that it works (that previous failed with the current implementation).

The reason it failed on this type of input is that validate_file_options in [implementation.js](https://github.com/MuchtarSalimov/filer/blob/master/src/filesystem/implementation.js) only checks if the parameter is null, a function, or a string. If it is something else (which in this case in an object), it just returns it as-is. But in the case of having an object but not having an encoding specified (as in { flags: 'a' }),  options.encoding is not set to the default value.

Fixes #463