### PR TITLE
Fixed #548 for rename()

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -933,13 +933,9 @@ function link_node(context, oldpath, newpath, callback) {
       callback(error);
     } else {
       newDirectoryData = result;
-      if(_(newDirectoryData).has(newname)) {
-        callback(new Errors.EEXIST('newpath resolves to an existing file', newname));
-      } else {
-        newDirectoryData[newname] = oldDirectoryData[oldname];
-        fileNodeID = newDirectoryData[newname].id;
-        context.putObject(newDirectoryNode.data, newDirectoryData, read_file_node);
-      }
+      newDirectoryData[newname] = oldDirectoryData[oldname];
+      fileNodeID = newDirectoryData[newname].id;
+      context.putObject(newDirectoryNode.data, newDirectoryData, read_file_node);
     }
   }
 

--- a/tests/spec/fs.rename.spec.js
+++ b/tests/spec/fs.rename.spec.js
@@ -10,6 +10,23 @@ describe('fs.rename', function() {
     expect(fs.rename).to.be.a('function');
   });
 
+  it('should be able to rename an existing file to the same filename', function(done) {
+    var fs = util.fs();
+
+    fs.open('/myfile', 'w+', function(error, fd) {
+      if(error) throw error;
+
+      fs.close(fd, function(error) {
+        if(error) throw error;
+
+        fs.rename('/myfile', '/myfile', function(error) {
+          expect(error).not.to.exist; 
+          done();
+        });
+      });
+    });
+  });
+
   it('should rename an existing file', function(done) {
     var complete1 = false;
     var complete2 = false;


### PR DESCRIPTION
- Fixed [issue-548](https://github.com/filerjs/filer/issues/548): rename() failed to rename a file to the same filename
- Also added a test that solves [issue-493](https://github.com/filerjs/filer/issues/493). It tests case when oldPath==newPath
- So, this PR can be merged with [pull-502](https://github.com/filerjs/filer/pull/502)