### PR TITLE
Update fs.stat.spec.js to not have uncaught exception on promise

### DIFF
--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -99,7 +99,10 @@ describe('fs.stat', function() {
   
   it('should return a promise', function() {
     var fs = util.fs();
-    expect(fs.promises.stat()).to.be.a('Promise');
+
+    var p = fs.promises.stat('/');
+    expect(p).to.be.a('Promise');
+    return p;
   });
   
   it('(promise) should return a stat object if file exists', function() {


### PR DESCRIPTION
This test is causing an uncaught exception because we try to `stat` a null path.  Passing it `/` lets it work.