### PR TITLE
Fix #568: switch all stats.type checks in tests/ to use is*() methods

### DIFF
--- a/tests/spec/fs.lstat.spec.js
+++ b/tests/spec/fs.lstat.spec.js
@@ -27,7 +27,7 @@ describe('fs.lstat', function() {
     fs.lstat('/', function(error, result) {
       expect(error).not.to.exist;
       expect(result).to.exist;
-      expect(result.type).to.equal('DIRECTORY');
+      expect(result.isDirectory()).to.be.true;
       done();
     });
   });
@@ -41,7 +41,7 @@ describe('fs.lstat', function() {
       fs.lstat('/mylink', function(error, result) {
         expect(error).not.to.exist;
         expect(result).to.exist;
-        expect(result.type).to.equal('SYMLINK');
+        expect(result.isSymbolicLink()).to.be.true;
         done();
       });
     });

--- a/tests/spec/fs.mkdir.spec.js
+++ b/tests/spec/fs.mkdir.spec.js
@@ -40,7 +40,7 @@ describe('fs.mkdir', function () {
       fs.stat('/tmp', function (error, stats) {
         expect(error).not.to.exist;
         expect(stats).to.exist;
-        expect(stats.type).to.equal('DIRECTORY');
+        expect(stats.isDirectory()).to.be.true;
         done();
       });
     });
@@ -83,7 +83,7 @@ describe('fs.promises.mkdir', function () {
       .then(() => fs.promises.stat('/tmp'))
       .then(stats => {
         expect(stats).to.exist;
-        expect(stats.type).to.equal('DIRECTORY');
+        expect(stats.isDirectory()).to.be.true;
       });
   });
 

--- a/tests/spec/fs.mknod.spec.js
+++ b/tests/spec/fs.mknod.spec.js
@@ -60,7 +60,7 @@ describe('fs.mknod', function(){
 
       fs.stat('/dir', function(error, stats){
         expect(error).not.to.exist;
-        expect(stats.type).to.equal('DIRECTORY');
+        expect(stats.isDirectory()).to.be.true;
         done();
       });
     });
@@ -74,7 +74,7 @@ describe('fs.mknod', function(){
 
       fs.stat('/file', function(error, result){
         expect(error).not.to.exist;
-        expect(result.type).to.equal('FILE');
+        expect(result.isFile()).to.be.true;
         done();
       });
     });

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -100,7 +100,7 @@ describe('fs.open', function() {
       fs.stat('/myfile', function(error, result) {
         expect(error).not.to.exist;
         expect(result).to.exist;
-        expect(result.type).to.equal('FILE');
+        expect(result.isFile()).to.be.true;
         done();
       });
     });

--- a/tests/spec/fs.spec.js
+++ b/tests/spec/fs.spec.js
@@ -17,7 +17,7 @@ describe('fs', function() {
     fs.stat('/', function(error, result) {
       expect(error).not.to.exist;
       expect(result).to.exist;
-      expect(result.type).to.equal('DIRECTORY');
+      expect(result.isDirectory()).to.be.true;
       done();
     });
   });

--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -117,7 +117,7 @@ describe('fs.stat', function() {
         expect(result.atime).to.be.a('number');
         expect(result.mtime).to.be.a('number');
         expect(result.ctime).to.be.a('number');
-        expect(result.type).to.equal('DIRECTORY');
+        expect(result.isDirectory()).to.be.true;
       }); 
   });
 });

--- a/tests/spec/fs.symlink.spec.js
+++ b/tests/spec/fs.symlink.spec.js
@@ -38,7 +38,7 @@ describe('fs.symlink', function() {
 
       fs.stat('/myfile', function(err, stats) {
         expect(error).not.to.exist;
-        expect(stats.type).to.equal('DIRECTORY');
+        expect(stats.isDirectory()).to.be.true;
         done();
       });
     });

--- a/tests/spec/fs.unlink.spec.js
+++ b/tests/spec/fs.unlink.spec.js
@@ -97,7 +97,7 @@ describe('fs.unlink', function() {
         fs.stat('/mydir', function (error, stats) {
           expect(error).not.to.exist;
           expect(stats).to.exist;
-          expect(stats.type).to.equal('DIRECTORY');
+          expect(stats.isDirectory()).to.be.true;
           done();
         });
       });

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -24,7 +24,7 @@ describe('fs.write', function() {
 
         fs.stat('/myfile', function(error, result) {
           expect(error).not.to.exist;
-          expect(result.type).to.equal('FILE');
+          expect(result.isFile()).to.be.true;
           expect(result.size).to.equal(buffer.length);
           done();
         });

--- a/tests/spec/node-js/simple/test-fs-mkdir.js
+++ b/tests/spec/node-js/simple/test-fs-mkdir.js
@@ -15,7 +15,7 @@ describe('node.js tests: https://github.com/joyent/node/blob/master/test/simple/
       fs.stat(pathname, function(error, result) {
         expect(error).not.to.exist;
         expect(result).to.exist;
-        expect(result.type).to.equal('DIRECTORY');
+        expect(result.isDirectory()).to.be.true;
         done();
       });
     });
@@ -31,7 +31,7 @@ describe('node.js tests: https://github.com/joyent/node/blob/master/test/simple/
       fs.stat(pathname, function(error, result) {
         expect(error).not.to.exist;
         expect(result).to.exist;
-        expect(result.type).to.equal('DIRECTORY');
+        expect(result.isDirectory()).to.be.true;
         done();
       });
     });

--- a/tests/spec/shell/ls.spec.js
+++ b/tests/spec/shell/ls.spec.js
@@ -43,7 +43,7 @@ describe('FileSystemShell.ls', function() {
           expect(item0.nlinks).to.equal(1);
           expect(item0.size).to.equal(1);
           expect(item0.mtime).to.be.a('number');
-          expect(item0.type).to.equal('FILE');
+          expect(item0.isFile()).to.be.true;
           expect(item0.contents).not.to.exist;
 
           var item1 = list[1];
@@ -51,7 +51,7 @@ describe('FileSystemShell.ls', function() {
           expect(item1.nlinks).to.equal(1);
           expect(item1.size).to.equal(2);
           expect(item1.mtime).to.be.a('number');
-          expect(item1.type).to.equal('FILE');
+          expect(item1.isFile()).to.be.true;
           expect(item0.contents).not.to.exist;
 
           done();
@@ -88,7 +88,7 @@ describe('FileSystemShell.ls', function() {
                   expect(item.nlinks).to.equal(1);
                   expect(item.size).to.be.a('number');
                   expect(item.mtime).to.be.a('number');
-                  expect(item.type).to.equal('DIRECTORY');
+                  expect(item.isDirectory()).to.be.true;
                   expect(item.contents).not.to.exist;
                   break;
                 case 'file':
@@ -96,7 +96,7 @@ describe('FileSystemShell.ls', function() {
                   expect(item.nlinks).to.equal(1);
                   expect(item.size).to.equal(1);
                   expect(item.mtime).to.be.a('number');
-                  expect(item.type).to.equal('FILE');
+                  expect(item.isFile()).to.be.true;
                   expect(item.contents).not.to.exist;
                   break;
                 default:
@@ -147,7 +147,7 @@ describe('FileSystemShell.ls', function() {
                     expect(item.nlinks).to.equal(1);
                     expect(item.size).to.be.a('number');
                     expect(item.mtime).to.be.a('number');
-                    expect(item.type).to.equal('DIRECTORY');
+                    expect(item.isDirectory()).to.be.true;
                     expect(item.contents).to.exist;
                     expect(item.contents.length).to.equal(1);
                     var contents0 = item.contents[0];
@@ -155,7 +155,7 @@ describe('FileSystemShell.ls', function() {
                     expect(contents0.nlinks).to.equal(1);
                     expect(contents0.size).to.equal(1);
                     expect(contents0.mtime).to.be.a('number');
-                    expect(contents0.type).to.equal('FILE');
+                    expect(contents0.isFile()).to.be.true;
                     expect(contents0.contents).not.to.exist;
                     break;
                   case 'file':
@@ -163,7 +163,7 @@ describe('FileSystemShell.ls', function() {
                     expect(item.nlinks).to.equal(1);
                     expect(item.size).to.equal(1);
                     expect(item.mtime).to.be.a('number');
-                    expect(item.type).to.equal('FILE');
+                    expect(item.isFile()).to.be.true;
                     expect(item.contents).not.to.exist;
                     break;
                   default:

--- a/tests/spec/shell/touch.spec.js
+++ b/tests/spec/shell/touch.spec.js
@@ -26,7 +26,7 @@ describe('FileSystemShell.touch', function() {
 
       fs.stat('/newfile', function(error, stats) {
         expect(error).not.to.exist;
-        expect(stats.type).to.equal('FILE');
+        expect(stats.isFile()).to.be.true;
         done();
       });
     });


### PR DESCRIPTION
[Fix Issue568](https://github.com/filerjs/filer/issues/568)

Change all 
```
expect(result.type).to.equal('DIRECTORY'); 
expect(result.type).to.equal('FILE')
expect(result.type).to.equal('SYMLINK');
```
to

```
expect(result.isDirectory()).to.be.true;
expect(result.isFile()).to.be.true;
expect(result.type).to.equal('SYMLINK');
```

Change all 
```
expect(stats.type).to.equal('DIRECTORY');
expect(stats.type).to.equal('FILE');
expect(stats.type).to.equal('SYMLINK');

```

to

```
expect(stats.isDirectory()).to.be.true;
expect(stats.isFile()).to.be.true;
expect(stats.type).to.equal('SYMLINK');

```

In the following 11 files:
1. tests/spec/fs.lstat.spec.js
2. tests/spec/fs.mkdir.spec.js
3. tests/spec/fs.mknod.spec.js
4. tests/spec/fs.open.spec.js
5. tests/spec/fs.spec.js
6. tests/spec/fs.stat.spec.js
7. tests/spec/fs.symlink.spec.js
8. tests/spec/fs.unlink.spec.js
9. tests/spec/fs.write.spec.js
10. tests/spec/node-js/simple/test-fs-mkdir.js
11. tests/spec/shell/touch.spec.js

Let me know if there has more file need to be changed, I will change them. Because I made these changes based on the search result, maybe I didn't get all the file need to be changed.


