### PR TITLE
Improve coverage: add test for rel paths with symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,10 +563,12 @@ Create a symbolic link to the file at `dstPath` containing the path `srcPath`. A
 Symbolic links are files that point to other paths.
 
 NOTE: Filer allows for, but ignores the optional `type` parameter used in node.js.
+The `srcPath` may be a relative path, which will be resolved relative to `dstPath`
 
 Example:
 
 ```javascript
+// Absolute path
 fs.symlink('/logs/august.log', '/logs/current', function(err) {
   if(err) throw err;
   fs.readFile('/logs/current', 'utf8', function(err, data) {
@@ -574,11 +576,21 @@ fs.symlink('/logs/august.log', '/logs/current', function(err) {
     var currentLog = data;
   });
 });
+
+// Relative path
+fs.symlink('../file', '/dir/symlink', function(err) {
+  if(err) throw err;
+  // The /dir/symlink file is now a symlink to /file
+});
 ```
 
 #### fs.readlink(path, callback)<a name="readlink"></a>
 
-Reads the contents of a symbolic link. Asynchronous [readlink(2)](http://pubs.opengroup.org/onlinepubs/009695399/functions/readlink.html). Callback gets `(error, linkContents)`, where `linkContents` is a string containing the symbolic link's link path.
+Reads the contents of a symbolic link. Asynchronous [readlink(2)](http://pubs.opengroup.org/onlinepubs/009695399/functions/readlink.html).
+Callback gets `(error, linkContents)`, where `linkContents` is a string
+containing the symbolic link's link path.  If the original `srcPath` given
+to `symlink()` was a relative path, it will be fully resolved relative
+to `dstPath` when returned by `readlink()`.
 
 Example:
 

--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -2347,8 +2347,7 @@ function symlink(fs, context, srcpath, dstpath, type, callback) {
   callback = arguments[arguments.length - 1];
 
   // Special Case: allow srcpath to be relative, which we normally don't permit.
-  // If the srcpath is relative, we assume it's relative to the dirpath of 
-  // dstpath.
+  // If the srcpath is relative, we assume it's relative to the dirpath of dstpath.
   if(!pathCheck(srcpath, true, callback)) return;
   if(!pathCheck(dstpath, callback)) return;
 

--- a/tests/spec/fs.readlink.spec.js
+++ b/tests/spec/fs.readlink.spec.js
@@ -43,4 +43,32 @@ describe('fs.readlink', function() {
       });
     });
   });
+
+  it('should allow relative paths, but resolve to the dstpath', function(done) {
+    var fs = util.fs();
+    var contents = 'contents';
+
+    fs.mkdir('/dir', function(error) {
+      if(error) throw error;
+
+      fs.writeFile('/file', contents, function(error) {
+        if(error) throw error;
+
+        fs.symlink('../file', '/dir/symlink', function(error) {
+          if(error) throw error;
+
+          fs.readlink('/dir/symlink', function(error, result) {
+            expect(error).not.to.exist;
+            expect(result).to.equal('../file');
+
+            fs.readFile('/dir/symlink', 'utf8', function(error, data) {
+              expect(error).not.to.exist;
+              expect(data).to.equal(contents);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Looking through coverage data, I noticed we don't have a test for passing a relative path as `src` for a symlink.  I added support for this in the summer, but apparently didn't add a test.

I've also filled out out the docs to mention that we support it.