### PR TITLE
Increase coverage: check for non-int with chown/fchown

### DIFF
--- a/tests/spec/fs.chown.spec.js
+++ b/tests/spec/fs.chown.spec.js
@@ -27,6 +27,62 @@ describe('fs.chown, fs.fchown', function() {
     });
   });
 
+  it('fchown should expect an interger value for uid', function(done) {
+    var fs = util.fs();
+
+    fs.open('/file', 'w', function(err, fd) {
+      if(err) throw err;
+
+      fs.fchown(fd, '1001', 1001, function(err) {
+        expect(err).to.exist;
+        expect(err.code).to.equal('EINVAL');
+        done();
+      });
+    });
+  });
+
+  it('chown should expect an interger value for uid', function(done) {
+    var fs = util.fs();
+
+    fs.writeFile('/file', 'w', function(err) {
+      if(err) throw err;
+
+      fs.chown('/file', '1001', 1001, function(err) {
+        expect(err).to.exist;
+        expect(err.code).to.equal('EINVAL');
+        done();
+      });
+    });
+  });
+
+  it('fchown should expect an interger value for gid', function(done) {
+    var fs = util.fs();
+
+    fs.open('/file', 'w', function(err, fd) {
+      if(err) throw err;
+
+      fs.fchown(fd, 1001, '1001', function(err) {
+        expect(err).to.exist;
+        expect(err.code).to.equal('EINVAL');
+        done();
+      });
+    });
+  });
+
+  it('chown should expect an interger value for gid', function(done) {
+    var fs = util.fs();
+
+    fs.writeFile('/file', 'w', function(err) {
+      if(err) throw err;
+
+      fs.chown('/file', 1001, '1001', function(err) {
+        expect(err).to.exist;
+        expect(err.code).to.equal('EINVAL');
+        done();
+      });
+    });
+  });
+
   it('should allow updating gid and uid for a file', function(done) {
     var fs = util.fs();
 


### PR DESCRIPTION
We're missing tests for the case that `uid` and `gid` aren't integers with `chown` and `fchown`.  This improves coverage for those cases.