### PR TITLE
Add Headless Firefox test support, fix failing truncate test in Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-sudo: true
-
 language: node_js
 node_js:
   - "lts/*"
+
+env:
+  - MOZ_HEADLESS=1
 
 # Setup headless Chrome support
 # https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Chrome-addon-in-the-headless-mode
 addons:
   chrome: stable
+  firefox: latest
+
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,10 +1,8 @@
 module.exports = function(config) {
   config.set({
-    browsers: ['ChromeHeadless'],
     singleRun: true,
     basePath: '',
     files: ['tests/dist/index.js'],
-
     frameworks: ['mocha', 'chai'],
     reporters: ['mocha'],
     client: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5227,6 +5227,12 @@
         "which": "^1.2.1"
       }
     },
+    "karma-firefox-launcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
+      "integrity": "sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==",
+      "dev": true
+    },
     "karma-mocha": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,13 @@
     "test": "npm run karma-mocha",
     "prebuild": "parcel build --global Filer src/index.js --no-minify --out-file filer.js",
     "build": "parcel build --global Filer src/index.js --out-file filer.min.js --detailed-report",
-    "prekarma-mocha": "parcel build tests/index.js --no-source-maps --out-dir tests/dist",
-    "karma-mocha": "karma start karma.conf.js",
+    "build-tests": "parcel build tests/index.js --no-source-maps --out-dir tests/dist",
+    "prekarma-mocha-firefox": "npm run build-tests",
+    "karma-mocha-firefox": "karma start karma.conf.js --browsers FirefoxHeadless",
+    "prekarma-mocha-chrome": "npm run build-tests",
+    "karma-mocha-chrome": "karma start karma.conf.js --browsers ChromeHeadless",
+    "prekarma-mocha": "npm run build-tests",
+    "karma-mocha": "karma start karma.conf.js --browsers ChromeHeadless,FirefoxHeadless",
     "coverage": "nyc mocha tests/index.js"
   },
   "repository": {
@@ -45,6 +50,7 @@
     "karma": "^3.0.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "mocha": "^5.2.0",

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,5 +1,3 @@
-var Errors = require('./errors.js');
-
 function guid() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
@@ -9,22 +7,7 @@ function guid() {
 
 function nop() {}
 
-function validateInteger(value, name) {
-  let err;
-
-  if (typeof value !== 'number')
-    err = new Errors.EINVAL(name, 'number', value);
-
-  if (err) {
-    Error.captureStackTrace(err, validateInteger);
-    throw err;
-  }
-
-  return value;
-}
-
 module.exports = {
   guid: guid,
-  nop: nop,
-  validateInteger: validateInteger,
+  nop: nop
 };


### PR DESCRIPTION
This adds support for running our tests in Firefox (headless) to match what we already do with Chrome (headless).  It's already found 1 bug! which I've fixed in this PR as well.  I've also added `npm` scripts for running the tests in each separate browser if people need to.