### PR TITLE
Fix #577: deal with promise exceptions and test console spam

### DIFF
--- a/tests/spec/fs.chmod.spec.js
+++ b/tests/spec/fs.chmod.spec.js
@@ -91,24 +91,12 @@ describe('fsPromise.chmod', function() {
     expect(typeof fsPromise.chmod).to.equal('function');
   });
 
-  it('should return a promise', function() {
-    var fsPromise = util.fs().promises;
-    expect(fsPromise.chmod()).to.be.a('Promise');
-  });
-
   it('should allow for updating mode of a given file', function() {
     var fsPromise = util.fs().promises;
 
     return fsPromise.open('/file', 'w')
-      .then( () => {
-        return fsPromise.chmod('/file', 0o444);
-      })
-      .then( () => {
-        return fsPromise.stat('/file');
-      })
-      .then( stats => {
-        expect(stats.mode & 0o444).to.equal(0o444);
-      })
-      .catch( err => { throw err; });
+      .then(() => fsPromise.chmod('/file', 0o444))
+      .then(() => fsPromise.stat('/file'))
+      .then(stats => expect(stats.mode & 0o444).to.equal(0o444));
   });
 });

--- a/tests/spec/fs.chown.spec.js
+++ b/tests/spec/fs.chown.spec.js
@@ -131,12 +131,12 @@ describe('fs.promises.chown', function(){
 
   it('should allow updating uid and gid for a file', function() {
     var fsPromises = util.fs().promises;
-    return fsPromises.writeFile('/file', 'data')
-      .then(() => 
-        fsPromises.chown('/file', 500, 500))
-      .then(() => 
-        fsPromises.stat('/file'))
-      .then((stats) =>{
+
+    return fsPromises
+      .writeFile('/file', 'data')
+      .then(() => fsPromises.chown('/file', 500, 500))
+      .then(() => fsPromises.stat('/file'))
+      .then((stats) => {
         expect(stats.uid).to.equal(500);
         expect(stats.gid).to.equal(500);
       });

--- a/tests/spec/fs.link.spec.js
+++ b/tests/spec/fs.link.spec.js
@@ -117,10 +117,20 @@ describe('fs.promises.link', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
-  it('should return a promise', function() {
-    var fsPromise = util.fs().promises;
-    var returnValue = fsPromise.link('/myfile', '/myotherfile');
-    expect(returnValue).to.be.a('promise');
+  it('should be a function', function(){
+    var fsPromises = util.fs().promises;
+    expect(fsPromises.link).to.be.a('function');
   });
 
+  it('should return a promise', function() {
+    var fsPromise = util.fs().promises;
+
+    var p = fsPromise
+      .writeFile('/myfile', '')
+      .then(() => fsPromise.link('/myfile', '/myotherfile'));
+    
+    expect(p).to.be.a('promise');
+    
+    return p;
+  });
 });

--- a/tests/spec/fs.readdir.spec.js
+++ b/tests/spec/fs.readdir.spec.js
@@ -59,7 +59,18 @@ describe('fs.readdir', function() {
     var fsPromises = util.fs().promises;
     expect(fsPromises.readdir).to.be.a('function');
   });
-  
+
+  it('should return an error if the path is a file', function() {
+    var fsPromises = util.fs().promises;
+
+    return fsPromises.writeFile('/myfile', 'contents')
+      .then(() => fsPromises.readdir('/myfile'))
+      .catch(error => {
+        expect(error).to.exist;
+        expect(error.code).to.equal('ENOTDIR');
+      });
+  });
+
   it('(promise) should return a list of files from an existing directory', function() {
     var fsPromises = util.fs().promises;
 
@@ -78,29 +89,6 @@ describe('fs.readdir', function() {
         expect(files).to.exist;
         expect(files.length).to.equal(1);
         expect(files[0]).to.equal('tmp');
-      })
-      .catch(error => {
-        expect(error).not.to.exist;
-      });
-  });
-});
-
-/**
- * fsPromises tests
- */
-
-describe('fsPromises.readdir', function() {
-  beforeEach(util.setup);
-  afterEach(util.cleanup);
-
-  it('should return an error if the path is a file', function() {
-    var fsPromises = util.fs().promises;
-
-    return fsPromises.writeFile('/myfile', 'contents')
-      .then(() => fsPromises.readdir('/myfile'))
-      .catch(error => {
-        expect(error).to.exist;
-        expect(error.code).to.equal('ENOTDIR');
       });
   });
 });

--- a/tests/spec/fs.utimes.spec.js
+++ b/tests/spec/fs.utimes.spec.js
@@ -151,55 +151,39 @@ describe('fs.promises.utimes', function () {
     expect(fs.utimes).to.be.a('function');
   });
 
-  it('should return a promise', function() {
-    var fs = util.fs().promises;
-    expect(fs.utimes()).to.be.a('Promise');
-  });
-
   it('should error when atime is negative', function () {
     var fs = util.fs().promises;
-    return fs.writeFile('/testfile', '')
-      .then(function () {
-        fs.utimes('/testfile', -1, Date.now())
-          .catch(function (error) {
-            expect(error).to.exist;
-            expect(error.code).to.equal('EINVAL');
-          });
-      })
+
+    return fs
+      .writeFile('/testfile', '')
+      .then(() => fs.utimes('/testfile', -1, Date.now()))
       .catch(function (error) {
-        throw error;
+        expect(error).to.exist;
+        expect(error.code).to.equal('EINVAL');
       });
   });
 
   it('should error when mtime is negative', function () {
     var fs = util.fs().promises;
 
-    return fs.writeFile('/testfile', '')
-      .then(function () {
-        fs.utimes('/testfile', Date.now(), -1)
-          .catch(function (error) {
-            expect(error).to.exist;
-            expect(error.code).to.equal('EINVAL');
-          });
-      })
+    return fs
+      .writeFile('/testfile', '')
+      .then(() => fs.utimes('/testfile', Date.now(), -1))
       .catch(function (error) {
-        throw error;
+        expect(error).to.exist;
+        expect(error.code).to.equal('EINVAL');
       });
   });
 
   it('should error when mtime is an invalid number', function () {
     var fs = util.fs().promises;
 
-    return fs.writeFile('/testfile', '')
-      .then(function () {
-        fs.utimes('/testfile', Date.now(), 'invalid datetime')
-          .catch(function (error) {
-            expect(error).to.exist;
-            expect(error.code).to.equal('EINVAL');
-          });
-      })
+    return fs
+      .writeFile('/testfile', '')
+      .then(() => fs.utimes('/testfile', Date.now(), 'invalid datetime'))
       .catch(function (error) {
-        throw error;
+        expect(error).to.exist;
+        expect(error.code).to.equal('EINVAL');
       });
   });
 
@@ -208,25 +192,11 @@ describe('fs.promises.utimes', function () {
     var atime = Date.parse('1 Oct 2000 15:33:22');
     var mtime = Date.parse('30 Sep 2000 06:43:54');
 
-    return fs.writeFile('/testfile', '')
-      .then(function () {
-        fs.utimes('/testfile', atime, mtime)
-          .then(function () {
-            fs.stat('/testfile')
-              .then(function (stat) {
-                expect(stat.mtime).to.equal(mtime);
-              })
-              .catch(function (error) {
-                expect(error).not.to.exist;
-              });
-          })
-          .catch(function (error) {
-            expect(error).not.to.exist;
-          });
-      })
-      .catch(function (error) {
-        throw error;
-      });
+    return fs
+      .writeFile('/testfile', '')
+      .then(() => fs.utimes('/testfile', atime, mtime))
+      .then(() => fs.stat('/testfile'))
+      .then(stat => expect(stat.mtime).to.equal(mtime));
   });
 
   it('should update atime and mtime of directory path', function () {
@@ -234,53 +204,32 @@ describe('fs.promises.utimes', function () {
     var atime = Date.parse('1 Oct 2000 15:33:22');
     var mtime = Date.parse('30 Sep 2000 06:43:54');
 
-    return fs.mkdir('/testdir')
-      .then(function () {
-        fs.utimes('/testdir', atime, mtime)
-          .then(function () {
-            fs.stat('/testdir')
-              .then(function (stat) {
-                expect(stat.mtime).to.equal(mtime);
-              })
-              .catch(function (error) {
-                expect(error).not.to.exist;
-              });
-          })
-          .catch(function (error) {
-            expect(error).not.to.exist;
-          });
-      })
-      .catch(function (error) {
-        throw error;
+    return fs
+      .mkdir('/testdir')
+      .then(() => fs.utimes('/testdir', atime, mtime))
+      .then(() => fs.stat('/testdir'))
+      .then(stat => {
+        expect(stat.mtime).to.equal(mtime);
       });
   });
 
   it('should update atime and mtime using current time if arguments are null', function () {
     var fs = util.fs().promises;
+    var t1;
 
-    return fs.writeFile('/myfile', '')
-      .then(function () {
-        var then = Date.now();
-        fs.utimes('/myfile', null, null)
-          .then(function () {
-            fs.stat('/myfile')
-              .then(function (stat) {
-                // Note: testing estimation as time may differ by a couple of milliseconds
-                // This number should be increased if tests are on slow systems
-                var delta = Date.now() - then;
-                expect(then - stat.atime).to.be.at.most(delta);
-                expect(then - stat.mtime).to.be.at.most(delta);
-              })
-              .catch(function (error) {
-                expect(error).not.to.exist;
-              });
-          })
-          .catch(function (error) {
-            expect(error).not.to.exist;
-          });
+    return fs
+      .writeFile('/myfile', '')
+      .then(() => {
+        t1 = Date.now();
+        return fs.utimes('/myfile', null, null);
       })
-      .catch(function (error) {
-        throw error;
+      .then(() => fs.stat('/myfile'))
+      .then(stat => {
+        // Note: testing estimation as time may differ by a couple of milliseconds
+        // This number should be increased if tests are on slow systems
+        var delta = Date.now() - t1;
+        expect(t1 - stat.atime).to.be.at.most(delta);
+        expect(t1 - stat.mtime).to.be.at.most(delta);
       });
   });
 });

--- a/tests/spec/fs.watch.spec.js
+++ b/tests/spec/fs.watch.spec.js
@@ -5,7 +5,7 @@ describe('fs.watch', function() {
   // Our watch infrastucture is dependent on document.localStorage
   // see lib/intercom.js. Bail if we don't have access to it.
   before(function() {
-    if(!(global.document && global.document.localStorage)) {
+    if(typeof global.localStorage === 'undefined') {
       /* eslint no-console: 0 */
       console.log('Skipping fs.watch() tests--not supported in current environment.');
       this.skip();


### PR DESCRIPTION
This cleans up a bunch of noise and false exceptions in tests.  I need to go over and clean up a bunch of the Promise based tests, but will do that once I land the rest of the student PRs.