### PR TITLE
Fix #337: Pick up sedge's changes from https://github.com/sedge/filer/commit/3c49743559ae32c2c72fbacfaea948fb7a520905

### DIFF
--- a/tests/spec/shell/env.spec.js
+++ b/tests/spec/shell/env.spec.js
@@ -35,7 +35,7 @@ describe('FileSystemShell.env', function() {
     var fs = util.fs();
     var shell = new fs.Shell();
 
-    shell.cat(null, function(error, list) {
+    shell.ls(null, function(error, list) {
       expect(error).to.exist;
       expect(error.code).to.equal('EINVAL');
       expect(list).not.to.exist;

--- a/tests/spec/shell/ls.spec.js
+++ b/tests/spec/shell/ls.spec.js
@@ -14,7 +14,7 @@ describe('FileSystemShell.ls', function() {
     var fs = util.fs();
     var shell = new fs.Shell();
 
-    shell.cat(null, function(error, list) {
+    shell.ls(null, function(error, list) {
       expect(error).to.exist;
       expect(error.code).to.equal('EINVAL');
       expect(list).not.to.exist;


### PR DESCRIPTION
Cleaning up old issues/PRs, and this grabs the `ls` vs. `cat` typos @sedge fixed in the commits linked at bottom of https://github.com/filerjs/filer/issues/337.