### PR TITLE
Fix issue-588: Remove fs.exists() console spam

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1925,7 +1925,6 @@ function exists(fs, context, path, callback) {
   function cb(err) {
     callback(err ? false : true);
   }
-  console.warn('This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback');// eslint-disable-line no-console
   stat(fs, context, path, cb);
 }
 


### PR DESCRIPTION
Fix [issue-588](https://github.com/filerjs/filer/issues/588)
After removing the line
'''
 console.warn('This method is deprecated. For more details see https://nodejs.org/api/fs.html#fs_fs_exists_path_callback');// eslint-disable-line no-console
'''
all tests are passed, but the program will automatically launch my Firefox browser. It's never happened before when I use the ''npm test'' command. It's a new test feature, or I'm doing something wrong with it.
