### PR TITLE
Stop npm from spamming on test failures

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+loglevel=silent


### PR DESCRIPTION
Add `.npmrc` to [get rid of pointless npm spam](https://docs.npmjs.com/misc/config#loglevel) in the console.