### PR TITLE
Fix #639: run tests on Linux and Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
+sudo: false
 language: node_js
+
 node_js:
   - "lts/*"
 
+cache:
+  directories:
+    - "node_modules"
+
+os:
+  - linux
+  - osx
+
+# Setup headless Firefox and Chrome support
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Chrome-addon-in-the-headless-mode
 env:
   - MOZ_HEADLESS=1
-
-# Setup headless Chrome support
-# https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Chrome-addon-in-the-headless-mode
 addons:
   chrome: stable
   firefox: latest
-
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 


### PR DESCRIPTION
This updates our Travis config to try and do a few things:

* run tests on Chrome/Firefox on both Linux and MacOS (headless browser support doesn't seem to exist on Windows yet).
* add `node_modules` caching
* see if we can use `sudo:false` to speed up builds (not sure if this will work with our headless setup) 