### PR TITLE
Fix #633: fix test failure in coverage run

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,10 @@
         "semi": [
             "error",
             "always"
+        ],
+        "eqeqeq": [
+            "error",
+            "always"
         ]
     }
 }

--- a/src/filesystem/interface.js
+++ b/src/filesystem/interface.js
@@ -122,9 +122,9 @@ function FileSystem(options, callback) {
   this.queueOrRun = function(operation) {
     var error;
 
-    if(FS_READY == fs.readyState) {
+    if(FS_READY === fs.readyState) {
       operation.call(fs);
-    } else if(FS_ERROR == fs.readyState) {
+    } else if(FS_ERROR === fs.readyState) {
       error = new Errors.EFILESYSTEMERROR('unknown error');
     } else {
       queue.push(operation);

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,6 +1,6 @@
 function generateRandom(template) {
   return template.replace(/[xy]/g, function(c) {
-    var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+    var r = Math.random()*16|0, v = c === 'x' ? r : (r&0x3|0x8);
     return v.toString(16);
   });
 }

--- a/src/shell/shell.js
+++ b/src/shell/shell.js
@@ -411,7 +411,7 @@ Shell.prototype.mkdirp = function(path, callback) {
         var parent = Path.dirname(path);
         if(parent === '/') {
           fs.mkdir(path, function (err) {
-            if (err && err.code != 'EEXIST') {
+            if (err && err.code !== 'EEXIST') {
               callback(err);
               return;
             }
@@ -423,7 +423,7 @@ Shell.prototype.mkdirp = function(path, callback) {
           _mkdirp(parent, function (err) {
             if (err) return callback(err);
             fs.mkdir(path, function (err) {
-              if (err && err.code != 'EEXIST') {
+              if (err && err.code !== 'EEXIST') {
                 callback(err);
                 return;
               }

--- a/tests/spec/filer.spec.js
+++ b/tests/spec/filer.spec.js
@@ -15,8 +15,23 @@ describe('Filer', function() {
   });
 
   it('must honor the \'FORMAT\' flag', function(done) {
-    var fs = new Filer.FileSystem({name: 'local-test'});
-    var fs2 = new Filer.FileSystem({name: 'local-test'});
+    var name = 'local-test';
+    // Because we need to use a bunch of Filer filesystems
+    // in this test, we can't use the usual test infrastructure
+    // to create/manage the fs instance.  Pick the best one
+    // based on the testing environment (browser vs. node)
+    var providers = Filer.FileSystem.providers;
+    var Provider;
+    if(providers.IndexedDB.isSupported()) {
+      Provider = providers.IndexedDB;
+    } else if(providers.WebSQL.isSupported()) {
+      Provider = providers.WebSQL;
+    } else {
+      Provider = providers.Memory;
+    }
+
+    var fs = new Filer.FileSystem({name, provider: new Provider(name)});
+    var fs2 = new Filer.FileSystem({name, provider: new Provider(name)});
 
     fs.mkdir('/test', function(err){
       if(err) throw err;
@@ -27,7 +42,7 @@ describe('Filer', function() {
         expect(list).to.exist;
         expect(list).to.have.length(1);
 
-        fs2 = new Filer.FileSystem({name: 'local-test', flags:['FORMAT']});
+        fs2 = new Filer.FileSystem({name, provider: new Provider(name), flags:['FORMAT']});
         fs2.readdir('/', function(err, list2) {
           expect(err).to.not.exist;
           expect(list2).to.exist;


### PR DESCRIPTION
This fixes the error I found in #633.  It was due to use trying to use the `IndexedDB` provider instead of `Memory` when running the tests in node, which a coverage run does.

I've also fixed some lint issues I noted while fixing this: we weren't checking for `===` and `!==`.  Fixed.