### PR TITLE
Fix #602: fix mode masking issues, correct X_OK case in fs.access

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -451,17 +451,34 @@ function make_directory(context, path, callback) {
 }
 
 function access_file(context, path, mode, callback) {
+  const { F_OK, R_OK, W_OK, X_OK, S_IXUSR, S_IXGRP, S_IXOTH } = Constants.fsConstants;
+
   path = normalize(path);
   find_node(context, path, function (err, node) {
     if (err) {
       return callback(err);
     }
-    if(mode === Constants.F_OK){
+
+    // If we have a node, F_OK is true.
+    if(mode === F_OK) {
       return callback(null);
     }
-    if (!(mode & Constants.X_OK) || (node.mode & (Constants.fsConstants.S_IXUSR | Constants.fsConstants.S_IXGRP | Constants.fsConstants.S_IXOTH))){
+
+    var st_mode = validateAndMaskMode(node.mode, callback);
+    if(!st_mode) return;
+
+    // For any other combo of F_OK, R_OK, W_OK, always allow. Filer user is a root user,
+    // so existing files are always OK, readable, and writable
+    if(mode & (R_OK | W_OK)) {
       return callback(null);
     }
+
+    // For the case of X_OK, actually check if this file is executable
+    if ((mode & X_OK) && (st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
+      return callback(null);
+    }
+
+    // In any other case, the file isn't accessible
     callback(new Errors.EACCES('permission denied',path)) ; 
   });
 }
@@ -2221,14 +2238,14 @@ function futimes(fs, context, fd, atime, mtime, callback) {
 
 function chmod(fs, context, path, mode, callback) {
   if(!pathCheck(path, callback)) return;
-  mode = validateAndMaskMode(mode, 'mode', callback);
+  mode = validateAndMaskMode(mode, callback);
   if(!mode) return;
 
   chmod_file(context, path, mode, callback);
 }
 
 function fchmod(fs, context, fd, mode, callback) {
-  mode = validateAndMaskMode(mode, 'mode', callback);
+  mode = validateAndMaskMode(mode, callback);
   if(!mode) return;
 
   var ofd = fs.openFiles[fd];

--- a/tests/spec/fs.access.spec.js
+++ b/tests/spec/fs.access.spec.js
@@ -62,15 +62,14 @@ describe('fs.access', function () {
     });
   });
 
-  // See bug https://github.com/filerjs/filer/issues/602
-  it.skip('should return an error if file is not executable and mode = X_OK', function (done) {
+  it('should return an error if file is not executable and mode = X_OK', function (done) {
     var fs = util.fs();
     var contents = 'This is a file.';
    
     fs.writeFile('/myfile', contents, function (error) {
       if (error) throw error;
 
-      fs.chmod('/myfile', 0o644, function(error){
+      fs.chmod('/myfile', '644', function(error){
         if (error) throw error;
       
         fs.access('/myfile', fs.constants.X_OK, function (error) {
@@ -89,7 +88,7 @@ describe('fs.access', function () {
     fs.writeFile('/myfile', contents, function (error) {
       if (error) throw error;
 
-      fs.chmod('/myfile', 0o777, function(error){
+      fs.chmod('/myfile', 0o777, function(error) {
         if (error) throw error;
       
         fs.access('/myfile', fs.constants.X_OK, function (error) {


### PR DESCRIPTION
Spent a few minutes to finally track down the failing test case for `fs.access()` and `X_OK`.  In doing so I also found a few issues with how we were validating and masking `mode` in general, so it was worthwhile.

cc @deepanjali19, in case she wants to see what the fix was.