### PR TITLE
Refactor fs arg, open files management

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -1750,7 +1750,7 @@ function stat(fs, context, path, callback) {
     if(error) {
       callback(error);
     } else {
-      var stats = new Stats(path, result, fs.name);
+      var stats = new Stats(path, result, context.name);
       callback(null, stats);
     }
   }
@@ -1763,7 +1763,7 @@ function fstat(fs, context, fd, callback) {
     if(error) {
       callback(error);
     } else {
-      var stats = new Stats(ofd.path, result, fs.name);
+      var stats = new Stats(ofd.path, result, context.name);
       callback(null, stats);
     }
   }
@@ -1846,7 +1846,7 @@ function readFile(fs, context, path, options, callback) {
         return callback(err);
       }
 
-      var stats = new Stats(ofd.path, fstatResult, fs.name);
+      var stats = new Stats(ofd.path, fstatResult, context.name);
 
       if(stats.isDirectory()) {
         cleanup();
@@ -2427,7 +2427,7 @@ function lstat(fs, context, path, callback) {
     if(error) {
       callback(error);
     } else {
-      var stats = new Stats(path, result, fs.name);
+      var stats = new Stats(path, result, context.name);
       callback(null, stats);
     }
   }

--- a/src/filesystem/interface.js
+++ b/src/filesystem/interface.js
@@ -205,6 +205,7 @@ function FileSystem(options, callback) {
     function complete(error) {
       function wrappedContext(methodName) {
         var context = provider[methodName]();
+        context.name = name;
         context.flags = flags;
         context.changes = [];
         context.guid = wrappedGuidFn(context);

--- a/src/filesystem/interface.js
+++ b/src/filesystem/interface.js
@@ -22,7 +22,6 @@ var defaultGuidFn = require('../shared.js').guid;
 var STDIN = Constants.STDIN;
 var STDOUT = Constants.STDOUT;
 var STDERR = Constants.STDERR;
-var FIRST_DESCRIPTOR = Constants.FIRST_DESCRIPTOR;
 
 // The core fs operations live on impl
 var impl = require('./implementation.js');
@@ -100,22 +99,6 @@ function FileSystem(options, callback) {
 
   // Expose Shell constructor
   this.Shell = Shell.bind(undefined, this);
-
-  // Safely expose the list of open files and file
-  // descriptor management functions
-  var openFiles = {};
-  var nextDescriptor = FIRST_DESCRIPTOR;
-  Object.defineProperty(this, 'openFiles', {
-    get: function() { return openFiles; }
-  });
-  this.allocDescriptor = function(openFileDescription) {
-    var fd = nextDescriptor ++;
-    openFiles[fd] = openFileDescription;
-    return fd;
-  };
-  this.releaseDescriptor = function(fd) {
-    delete openFiles[fd];
-  };
 
   // Safely expose the operation queue
   var queue = [];
@@ -349,7 +332,7 @@ function FileSystem(options, callback) {
         // Forward this call to the impl's version, using the following
         // call signature, with complete() as the callback/last-arg now:
         // fn(fs, context, arg0, arg1, ... , complete);
-        var fnArgs = [fs, context].concat(args);
+        var fnArgs = [context].concat(args);
         impl[methodName].apply(null, fnArgs);
       });
       if(error) {

--- a/src/open-files.js
+++ b/src/open-files.js
@@ -1,0 +1,44 @@
+const { FIRST_DESCRIPTOR } = require('./constants');
+const openFiles = {};
+
+/**
+ * Start at FIRST_DESCRIPTOR and go until we find
+ * an empty file descriptor, then return it.
+ */
+const getEmptyDescriptor = () => {
+  let fd = FIRST_DESCRIPTOR;
+
+  while(getOpenFileDescription(fd)) {
+    fd++;
+  }
+
+  return fd;
+};
+
+/**
+ * Look up the open file description object for a given
+ * file descriptor.
+ */
+const getOpenFileDescription = ofd => openFiles[ofd];
+
+/**
+ * Allocate a new file descriptor for the given
+ * open file description. 
+ */
+const allocDescriptor = openFileDescription => {
+  const ofd = getEmptyDescriptor();
+  openFiles[ofd] = openFileDescription;
+  return ofd;
+};
+
+/**
+ * Release the given existing file descriptor created
+ * with allocDescriptor(). 
+ */
+const releaseDescriptor = ofd => delete openFiles[ofd];
+
+module.exports = {
+  allocDescriptor,
+  releaseDescriptor,
+  getOpenFileDescription
+};

--- a/tests/spec/fs.chown.spec.js
+++ b/tests/spec/fs.chown.spec.js
@@ -36,7 +36,7 @@ describe('fs.chown, fs.fchown', function() {
       fs.fchown(fd, '1001', 1001, function(err) {
         expect(err).to.exist;
         expect(err.code).to.equal('EINVAL');
-        done();
+        fs.close(fd, done);
       });
     });
   });
@@ -64,7 +64,7 @@ describe('fs.chown, fs.fchown', function() {
       fs.fchown(fd, 1001, '1001', function(err) {
         expect(err).to.exist;
         expect(err.code).to.equal('EINVAL');
-        done();
+        fs.close(fd, done);
       });
     });
   });

--- a/tests/spec/fs.close.spec.js
+++ b/tests/spec/fs.close.spec.js
@@ -23,6 +23,7 @@ describe('fs.close', function() {
 
         fs.read(fd, buffer, 0, buffer.length, undefined, function(error, result) {
           expect(error).to.exist;
+          expect(error.code).to.equal('EBADF');
           expect(result).not.to.exist;
           done();
         });

--- a/tests/spec/fs.lseek.spec.js
+++ b/tests/spec/fs.lseek.spec.js
@@ -77,7 +77,7 @@ describe('fs.lseek', function() {
                 expect(result.size).to.equal(offset + buffer.length);
                 var expected = Buffer.from([1, 2, 3, 1, 2, 3, 4, 5, 6, 7, 8]);
                 expect(result_buffer).to.deep.equal(expected);
-                done();
+                fs.close(fd, done);
               });
             });
           });
@@ -117,7 +117,7 @@ describe('fs.lseek', function() {
                 expect(result.size).to.equal(offset + 2 * buffer.length);
                 var expected = Buffer.from([1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 7, 8]);
                 expect(result_buffer).to.deep.equal(expected);
-                done();
+                fs.close(fd, done);
               });
             });
           });
@@ -163,7 +163,12 @@ describe('fs.lseek', function() {
 
                   var expected = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8]);
                   expect(result_buffer).to.deep.equal(expected);
-                  done();
+
+                  fs.close(fd1, function(error) {
+                    if(error) throw error;
+
+                    fs.close(fd2, done);
+                  });
                 });
               });
             });

--- a/tests/spec/fs.open.spec.js
+++ b/tests/spec/fs.open.spec.js
@@ -1,6 +1,6 @@
 var util = require('../lib/test-utils.js');
 var expect = require('chai').expect;
-var constants = require('../../src/constants.js');
+var { FIRST_DESCRIPTOR } = require('../../src/constants.js');
 
 describe('fs.open', function() {
   beforeEach(util.setup);
@@ -63,45 +63,68 @@ describe('fs.open', function() {
 
   it('should return a unique file descriptor', function(done) {
     var fs = util.fs();
-    var fd1;
 
     fs.open('/file1', 'w+', function(error, fd) {
       if(error) throw error;
       expect(error).not.to.exist;
       expect(fd).to.be.a('number');
 
-      fs.open('/file2', 'w+', function(error, fd) {
+      fs.open('/file2', 'w+', function(error, fd1) {
         if(error) throw error;
         expect(error).not.to.exist;
-        expect(fd).to.be.a('number');
-        expect(fd).not.to.equal(fd1);
-        done();
+        expect(fd1).to.be.a('number');
+        expect(fd1).not.to.equal(fd);
+
+        fs.close(fd, function(error) {
+          if(error) throw error;
+
+          fs.close(fd1, done);
+        });
       });
     });
   });
 
-  it('should return the argument value of the file descriptor index matching the value set by the first useable file descriptor constant', function(done) {
+  it('should return the argument value of the file descriptor index greater than or equal to the value set by the first useable file descriptor constant', function(done) {
     var fs = util.fs();
-    var firstFD = constants.FIRST_DESCRIPTOR;
 
     fs.open('/file1', 'w+', function(error, fd) {
       if(error) throw error;
-      expect(fd).to.equal(firstFD);
-      done();
+      expect(fd).to.equal(FIRST_DESCRIPTOR);
+      fs.close(fd, done);
+    });
+  });
+
+  it('should reuse file descriptors after closing', function(done) {
+    var fs = util.fs();
+
+    fs.open('/file1', 'w+', function(error, fd) {
+      if(error) throw error;
+      expect(fd).to.equal(FIRST_DESCRIPTOR);
+
+      fs.close(fd, function(error) {
+        if(error) throw error;
+
+        fs.open('/file1', 'w+', function(error, fd) {
+          if(error) throw error;
+          expect(fd).to.equal(FIRST_DESCRIPTOR);
+  
+          fs.close(fd, done);
+        });
+      });
     });
   });
 
   it('should create a new file when flagged for write', function(done) {
     var fs = util.fs();
 
-    fs.open('/myfile', 'w', function(error) {
+    fs.open('/myfile', 'w', function(error, fd) {
       if(error) throw error;
       
       fs.stat('/myfile', function(error, result) {
         expect(error).not.to.exist;
         expect(result).to.exist;
         expect(result.isFile()).to.be.true;
-        done();
+        fs.close(fd, done);
       });
     });
   });
@@ -110,7 +133,7 @@ describe('fs.open', function() {
   it('should create a new file, when flagged for write, and set the mode to the passed value', function(done) {
 
     var fs = util.fs();
-    fs.open('/myfile', 'w', 0o777, function(error) {
+    fs.open('/myfile', 'w', 0o777, function(error, fd) {
       if(error) throw error;
 
       fs.stat('/myfile', function(error, result) {
@@ -118,7 +141,7 @@ describe('fs.open', function() {
         expect(result).to.exist;
         expect(result.mode).to.exist;
         expect(result.mode & 0o777).to.equal(0o777);
-        done();
+        fs.close(fd, done);
       });
     });
   });
@@ -126,7 +149,7 @@ describe('fs.open', function() {
   it('should create a new file, but no mode is passed, so  the default value of 644 should be seen', function(done) {
 
     var fs = util.fs();
-    fs.open('/myfile', 'w', function(error) {
+    fs.open('/myfile', 'w', function(error, fd) {
       if(error) throw error;
 
       fs.stat('/myfile', function(error, result) {
@@ -134,7 +157,7 @@ describe('fs.open', function() {
         expect(result).to.exist;
         expect(result.mode).to.exist;
         expect(result.mode & 0o644).to.equal(0o644);
-        done();
+        fs.close(fd, done);
       });
     });
   });
@@ -162,8 +185,7 @@ describe('fs.open', function() {
             expect(error.code).to.equal('EBADF');
             expect(result).not.to.exist;
 
-            fs.close(fd);
-            done();
+            fs.close(fd, done);
           });
         });
       });
@@ -178,24 +200,5 @@ describe('fs.open', function() {
       expect(err.code).to.equal('EINVAL');
       done();
     });
-  });
-});
-
-/**
- * fsPromise.open() Tests
- **/
-describe('fsPromises.open', function() {
-  beforeEach(util.setup);
-  afterEach(util.cleanup);
-
-  it('should return an error if the parent path does not exist', function() {
-    var fsPromises = util.fs().promises;
-
-    return fsPromises.open('/tmp/myfile', 'w+')
-      .then(result => expect(result).not.to.exist)
-      .catch(error => {
-        expect(error).to.exist;
-        expect(error.code).to.equal('ENOENT');
-      });
   });
 });

--- a/tests/spec/fs.read.spec.js
+++ b/tests/spec/fs.read.spec.js
@@ -17,6 +17,7 @@ describe('fs.read', function() {
 
     fs.open('/myfile', 'w+', function(error, fd) {
       if(error) throw error;
+
       fs.write(fd, wbuffer, 0, wbuffer.length, 0, function(error, result) {
         if(error) throw error;
         expect(result).to.equal(wbuffer.length);
@@ -25,7 +26,7 @@ describe('fs.read', function() {
           expect(error).not.to.exist;
           expect(result).to.equal(rbuffer.length);
           expect(wbuffer).to.deep.equal(rbuffer);
-          done();
+          fs.close(fd, done);
         });
       });
     });
@@ -54,7 +55,7 @@ describe('fs.read', function() {
             expect(error).not.to.exist;
             expect(_result).to.equal(rbuffer.length);
             expect(wbuffer).to.deep.equal(rbuffer);
-            done();
+            fs.close(fd, done);
           });
         });
       });
@@ -77,7 +78,7 @@ describe('fs.read', function() {
           expect(error.code).to.equal('EISDIR');
           expect(result).to.equal(0);
           expect(buf).to.deep.equal(buf2);
-          done();
+          fs.close(fd, done);
         });
       });
     });

--- a/tests/spec/fs.stat.spec.js
+++ b/tests/spec/fs.stat.spec.js
@@ -113,7 +113,7 @@ describe('fs.stat', function() {
         expect(result['ctimeMs']).to.be.a('number');
         expect(result['type']).to.equal('FILE');
 
-        done();
+        fs.close(fd, done);
       });
     });
   });

--- a/tests/spec/fs.stats.spec.js
+++ b/tests/spec/fs.stats.spec.js
@@ -21,9 +21,11 @@ describe('fs.stats', function() {
 
       fs.open('/myfile', 'w+', function(error, fd) {
         if(error) throw error;
+
         fs.fstat(fd, function(error, stats) {
+          expect(error).not.to.exist;
           expect(stats.isFile()).to.be.true;
-          done();
+          fs.close(fd, done);
         });
       });
     });
@@ -50,6 +52,7 @@ describe('fs.stats', function() {
           fs.symlink('/myfile', '/myfilelink', function(error) {
             if(error) throw error;
             fs.lstat('/myfilelink', function(error, stats) {
+              expect(error).not.to.exist;
               expect(stats.isFile()).to.be.false;
               done();
             });
@@ -78,8 +81,9 @@ describe('fs.stats', function() {
       fs.open('/myfile', 'w+', function(error, fd) {
         if(error) throw error;
         fs.fstat(fd, function(error, stats) {
+          expect(error).not.to.exist;
           expect(stats.isDirectory()).to.be.false;
-          done();
+          fs.close(fd, done);
         });
       });
     });
@@ -178,8 +182,9 @@ describe('fs.stats', function() {
       fs.open('/myfile', 'w+', function(error, fd) {
         if(error) throw error;
         fs.fstat(fd, function(error, stats) {
+          expect(error).not.to.exist;
           expect(stats.isSymbolicLink()).to.be.false;
-          done();
+          fs.close(fd, done);
         });
       });
     });
@@ -290,7 +295,7 @@ describe('fs.stats', function() {
           if(err) throw err;
 
           expect(stats.name).to.equal(Path.basename(filepath));
-          done();
+          fs.close(fd, done);
         });
       });
     });

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -35,7 +35,7 @@ describe('fs.write', function() {
           expect(error).not.to.exist;
           expect(result.isFile()).to.be.true;
           expect(result.size).to.equal(buffer.length);
-          done();
+          fs.close(fd, done);
         });
       });
     });
@@ -62,7 +62,7 @@ describe('fs.write', function() {
             expect(error).not.to.exist;
             expect(_result).to.equal(2 * buffer.length);
             expect(result.size).to.equal(_result);
-            done();
+            fs.close(fd, done);
           });
         });
       });

--- a/tests/spec/fs.xattr.spec.js
+++ b/tests/spec/fs.xattr.spec.js
@@ -236,7 +236,7 @@ describe('fs.xattr', function() {
         fs.fgetxattr(ofd, 'test', function (error, value) {
           expect(error).not.to.exist;
           expect(value).to.equal('value');
-          done();
+          fs.close(ofd, done);
         });
       });
     });
@@ -368,7 +368,7 @@ describe('fs.xattr', function() {
             fs.fgetxattr(ofd, 'test', function (error) {
               expect(error).to.exist;
               expect(error.code).to.equal('ENOATTR');
-              done();
+              fs.close(ofd, done);
             });
           });
         });

--- a/tests/spec/node-js/simple/test-fs-watch.js
+++ b/tests/spec/node-js/simple/test-fs-watch.js
@@ -52,20 +52,30 @@ describe('node.js tests: https://github.com/joyent/node/blob/master/test/simple/
 
   it('should allow watches on dirs', function(done) {
     var fs = util.fs();
+
     fs.mkdir('/tmp', function(error) {
       if(error) throw error;
+      var steps = 0;
+
+      function cleanup() {
+        steps++;
+        
+        if(steps === 2) {
+          done();
+        }
+      }
 
       var watcher = fs.watch('/tmp', function(event, filename) {
         // TODO: node thinks this should be 'rename', need to add rename along with change.
         expect(event).to.equal('change');
         expect(filename).to.equal('/tmp');
         watcher.close();
-        done();
+        cleanup();
       });
 
       fs.open('/tmp/newfile.txt', 'w', function(error, fd) {
         if(error) throw error;
-        fs.close(fd);
+        fs.close(fd, cleanup);
       });
     });
   });

--- a/tests/spec/times.spec.js
+++ b/tests/spec/times.spec.js
@@ -517,7 +517,7 @@ describe('node times (atime, mtime, ctimeMs)', function() {
               expect(stats2.ctimeMs).to.be.at.least(stats1.ctimeMs);
               expect(stats2.mtimeMs).to.equal(stats1.mtimeMs);
               expect(stats2.atimeMs).to.be.at.least(stats1.atimeMs);
-              done();
+              fs.close(fd, done);
             });
           });
         });
@@ -568,7 +568,7 @@ describe('node times (atime, mtime, ctimeMs)', function() {
                 expect(stats2.ctimeMs).to.equal(stats1.ctimeMs);
                 expect(stats2.mtimeMs).to.equal(stats1.mtimeMs);
                 expect(stats2.atimeMs).to.equal(stats1.atimeMs);
-                done();
+                fs.close(fd, done);
               });
             });
           });
@@ -618,7 +618,7 @@ describe('node times (atime, mtime, ctimeMs)', function() {
                 expect(stats2.ctimeMs).to.be.at.least(stats1.ctimeMs);
                 expect(stats2.mtimeMs).to.equal(stats1.mtimeMs);
                 expect(stats2.atimeMs).to.be.at.least(stats1.atimeMs);
-                done();
+                fs.close(fd, done);
               });
             });
           });


### PR DESCRIPTION
This refactors how the file descriptors get managed.  My motivation is to move this off of the `fs` instance, and into its own private module.  I want to eventually be able to refactor `implementation.js` into separate modules per function, and will need to be able to get access to the open files without needing the `fs` instance.  This also fixes #28 by reusing old descriptors.