### PR TITLE
Support file:// URLs and Buffers for path args, throw when invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The node.js [path module](http://nodejs.org/api/path.html) is available via the 
 identical to the node.js (see [https://github.com/browserify/path-browserify](https://github.com/browserify/path-browserify)) version with the following differences:
 
 * The CWD always defaults to `/`
-* No support for Windows style paths
+* No support for Windows style paths (assume you are on a POSIX system)
 * Additional utility methods (see below)
 
 ```javascript
@@ -266,6 +266,21 @@ Filer.Path also includes the following extra methods:
 * `isNull(p)` returns `true` or `false` if the path contains a null character (`'\u0000'`)
 * `addTrailing(p)` returns the path `p` with a single trailing slash added
 * `removeTrailing(p)` returns the path `p` with trailing slash(es) removed
+
+[As with node.js](https://nodejs.org/api/fs.html#fs_file_paths), all methods below that
+accept a `path` argument as a `String` can also take a [`file://` URL](https://nodejs.org/api/fs.html#fs_url_object_support)
+or a `Buffer`. For example, all of the following cases will work the same way with Filer:
+
+```js
+// 1. path as a String
+fs.writeFile('/dir/file.txt', 'data', function(err) {...});
+
+// 2. path as a URL
+fs.writeFile(new URL('file:///dir/file.txt'), 'data', function(err) {...});
+
+// 3. path as a Buffer
+fs.writeFile(Buffer.from('/dir/file.txt'), 'data', function(err) {...});
+```
 
 #### Filer.Errors<a name="Errors"></a>
 

--- a/tests/bugs/issue270.js
+++ b/tests/bugs/issue270.js
@@ -5,23 +5,15 @@ describe('undefined and relative paths, issue270', function() {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
-  it('should fail with EINVAL when called on an undefined path', function(done) {
+  it('should fail with EINVAL when called on an undefined path', function() {
     var fs = util.fs();
-
-    fs.writeFile(undefined, 'data', function(err) {
-      expect(err).to.exist;
-      expect(err.code).to.equal('EINVAL');
-      done();
-    });
+    var fn = () => fs.writeFile(undefined, 'data');
+    expect(fn).to.throw();
   });
 
-  it('should fail with EINVAL when called on a relative path', function(done) {
+  it('should fail with EINVAL when called on a relative path', function() {
     var fs = util.fs();
-
-    fs.writeFile('relpath/file.txt', 'data', function(err) {
-      expect(err).to.exist;
-      expect(err.code).to.equal('EINVAL');
-      done();
-    });
+    var fn = () => fs.writeFile('relpath/file.txt', 'data');
+    expect(fn).to.throw();
   });
 });

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -10,14 +10,10 @@ describe('fs.write', function() {
     expect(fs.write).to.be.a('function');
   });
 
-  it('should error if file path is undefined',function(done) {
+  it('should error if file path is undefined', function() {
     var fs = util.fs();
-
-    fs.writeFile(undefined, 'data', function(error) {
-      expect(error).to.exist;
-      expect(error.code).to.equal('EINVAL');
-      done();
-    });
+    var fn = () => fs.writeFile(undefined, 'data');
+    expect(fn).to.throw();
   });
 
   it('should write data to a file', function(done) {

--- a/tests/spec/node-js/simple/test-fs-null-bytes.js
+++ b/tests/spec/node-js/simple/test-fs-null-bytes.js
@@ -9,23 +9,18 @@ describe('node.js tests: https://github.com/joyent/node/blob/master/test/simple/
     var checks = [];
     var fnCount = 0;
     var fnTotal = 16;
-    var expected = 'Path must be a string without null bytes.';
     var fs = util.fs();
 
     // Make sure function fails with null path error in callback.
     function check(fn) {
       var args = Array.prototype.slice.call(arguments, 1);
-      args = args.concat(function(err) {
-        checks.push(function(){
-          expect(err).to.exist;
-          expect(err.message).to.equal(expected);
-        });
-        fnCount++;
-        if(fnCount === fnTotal) {
-          done();
-        }
-      });
-      fn.apply(fs, args);
+      fn = () => fn.apply(fs, args);
+      expect(fn).to.throw();
+
+      fnCount++;
+      if(fnCount === fnTotal) {
+        done();
+      }
     }
 
     check(fs.link,        '/foo\u0000bar', 'foobar');


### PR DESCRIPTION
This updates our path handling logic to better match what node.js does.  Specifically, this:

1. adds support for `file://` URLs as paths
1. adds support for `Buffer` objects as paths
1. Changes our callback error pattern to a throw pattern, which is what node.js does.

It also moves the path validation to the interface method definition instead of having it happen later for each method call.  This should make it less likely that we forget to do it, or accidentally remove it.