### PR TITLE
Match node's layout for access modes on fs, with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ fs.mkdir('/home', function(err) {
 
 #### fs.access(path, [mode], callback)<a name="access"></a>
 
-Tests a user's permissions for the file or directory supplied in `path` argument. Asynchronous [access(2)](http://pubs.opengroup.org/onlinepubs/009695399/functions/access.html). Callback gets no additional arguments. The `mode` argument can be one of the following (constants are available on `fs.constants`):
+Tests a user's permissions for the file or directory supplied in `path` argument. Asynchronous [access(2)](http://pubs.opengroup.org/onlinepubs/009695399/functions/access.html). Callback gets no additional arguments. The `mode` argument can be one of the following (constants are available on `fs.constants` and `fs`):
 
 * `F_OK`: Test for existence of file.
 * `R_OK`: Test whether the file exists and grants read permission.
@@ -763,7 +763,7 @@ Example:
 
 ```javascript
 // Check if the file exists in the current directory.
-fs.access(file, fs.constants.F_OK, function(err) {
+fs.access(file, fs.F_OK, function(err) {
   console.log(`${file} ${err ? 'does not exist' : 'exists'}`);
 });
 ```

--- a/src/filesystem/interface.js
+++ b/src/filesystem/interface.js
@@ -151,6 +151,11 @@ function FileSystem(options, callback) {
 
   // Expose Node's fs.constants to users
   fs.constants = Constants.fsConstants;
+  // Node also forwards the access mode flags onto fs
+  fs.F_OK = Constants.fsConstants.F_OK;
+  fs.R_OK = Constants.fsConstants.R_OK;
+  fs.W_OK = Constants.fsConstants.W_OK;
+  fs.X_OK = Constants.fsConstants.X_OK;
 
   // Expose Shell constructor
   this.Shell = Shell.bind(undefined, this);

--- a/tests/spec/fs.access.spec.js
+++ b/tests/spec/fs.access.spec.js
@@ -5,6 +5,26 @@ describe('fs.access', function () {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
+  it('should expose access mode flags on fs and fs.constants', function() {
+    var fs = util.fs();
+
+    // F_OK
+    expect(fs.F_OK).to.equal(0);
+    expect(fs.constants.F_OK).to.equal(0);
+
+    // R_OK
+    expect(fs.R_OK).to.equal(4);
+    expect(fs.constants.R_OK).to.equal(4);
+
+    // W_OK
+    expect(fs.W_OK).to.equal(2);
+    expect(fs.constants.W_OK).to.equal(2);
+    
+    // X_OK
+    expect(fs.X_OK).to.equal(1);
+    expect(fs.constants.X_OK).to.equal(1);
+  });
+
   it('should be a function', function () {
     var fs = util.fs();
     expect(typeof fs.access).to.equal('function');


### PR DESCRIPTION
I noticed we don't forward the `fs.access` mode flags onto `fs` from `fs.constants` like node does.  This fixes that.