### PR TITLE
Changed fs.watch.spec.js according to filed issue-666

### DIFF
--- a/tests/spec/fs.watch.spec.js
+++ b/tests/spec/fs.watch.spec.js
@@ -1,5 +1,7 @@
-var util = require('../lib/test-utils.js');
-var expect = require('chai').expect;
+'use strict';
+
+const util   = require('../lib/test-utils.js');
+const expect = require('chai').expect;
 
 describe('fs.watch', function() {
   // Our watch infrastucture is dependent on document.localStorage
@@ -16,14 +18,14 @@ describe('fs.watch', function() {
   afterEach(util.cleanup);
 
   it('should be a function', function() {
-    var fs = util.fs();
+    const fs = util.fs();
     expect(typeof fs.watch).to.equal('function');
   });
 
   it('should get a change event when writing a file', function(done) {
-    var fs = util.fs();
+    const fs = util.fs();
 
-    var watcher = fs.watch('/myfile', function(event, filename) {
+    const watcher = fs.watch('/myfile', function(event, filename) {
       expect(event).to.equal('change');
       expect(filename).to.equal('/myfile');
       watcher.close();
@@ -36,9 +38,9 @@ describe('fs.watch', function() {
   });
 
   it('should get a change event when writing a file beneath root dir with recursive=true', function(done) {
-    var fs = util.fs();
+    const fs = util.fs();
 
-    var watcher = fs.watch('/', { recursive: true }, function(event, filename) {
+    const watcher = fs.watch('/', { recursive: true }, function(event, filename) {
       expect(event).to.equal('change');
       expect(filename).to.equal('/');
       watcher.close();
@@ -51,12 +53,12 @@ describe('fs.watch', function() {
   });
 
   it('should get a change event when writing a file in a dir with recursive=true', function(done) {
-    var fs = util.fs();
+    const fs = util.fs();
 
     fs.mkdir('/foo', function(err) {
       if(err) throw err;
 
-      var watcher = fs.watch('/foo', { recursive: true }, function(event, filename) {
+      const watcher = fs.watch('/foo', { recursive: true }, function(event, filename) {
         expect(event).to.equal('change');
         expect(filename).to.equal('/foo');
         watcher.close();
@@ -77,7 +79,7 @@ describe('fs.watch', function() {
 
   // Bug to deal with this is filed at https://github.com/filerjs/filer/issues/594
   it.skip('should get a change event when a hardlink is watched and the original file is changed', function(done) {
-    var fs = util.fs();
+    const fs = util.fs();
 
     fs.writeFile('/myfile', 'data', function(error) {
       if(error) throw error;
@@ -85,7 +87,7 @@ describe('fs.watch', function() {
       fs.link('/myfile', '/hardlink', function(error) {
         if(error) throw error;
 
-        var watcher = fs.watch('/hardlink', function(event, filename) {
+        const watcher = fs.watch('/hardlink', function(event, filename) {
           expect(event).to.equal('change');
           expect(filename).to.equal('/hardlink');
 
@@ -107,14 +109,14 @@ describe('fs.watch', function() {
   });
 
   it('should get a change event when renaming a file', function(done) {
-    var fs = util.fs();
+    const fs = util.fs();
 
     fs.writeFile('/myfile', 'data', function(error) {
       if(error) throw error;
 
       //Normaly A 'rename' event should be thrown, but filer doesn't support that event at this time.
       //For now renaming a file will throw a change event.
-      var watcher = fs.watch('/myfile', function(event, filename) {
+      const watcher = fs.watch('/myfile', function(event, filename) {
         expect(event).to.equal('change');
         expect(filename).to.equal('/myfile');
         watcher.close();


### PR DESCRIPTION
The file had its variable being declared with usage of "var" -> changed to "let" and "const" where applicable; added "use strict" at global scope.