### PR TITLE
Fix issue #672 : Refactor "filer/tests/spec/fs.mkdir.spec.js" to follow ES6 syntax with "const/let" instead of "var"

### DIFF
--- a/tests/spec/fs.mkdir.spec.js
+++ b/tests/spec/fs.mkdir.spec.js
@@ -12,7 +12,6 @@ describe('fs.mkdir', function () {
   });
 
   it('should return an error if part of the parent path does not exist', function (done) {
-    'use strict';
     const fs = util.fs();
 
     fs.mkdir('/tmp/mydir', function (error) {

--- a/tests/spec/fs.mkdir.spec.js
+++ b/tests/spec/fs.mkdir.spec.js
@@ -1,17 +1,19 @@
-var util = require('../lib/test-utils.js');
-var expect = require('chai').expect;
+'use strict';
+const util = require('../lib/test-utils.js');
+const expect = require('chai').expect;
 
 describe('fs.mkdir', function () {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
   it('should be a function', function () {
-    var fs = util.fs();
+    const fs = util.fs();
     expect(fs.mkdir).to.be.a('function');
   });
 
   it('should return an error if part of the parent path does not exist', function (done) {
-    var fs = util.fs();
+    'use strict';
+    const fs = util.fs();
 
     fs.mkdir('/tmp/mydir', function (error) {
       expect(error).to.exist;
@@ -21,7 +23,7 @@ describe('fs.mkdir', function () {
   });
 
   it('should return an error if the path already exists', function (done) {
-    var fs = util.fs();
+    const fs = util.fs();
 
     fs.mkdir('/', function (error) {
       expect(error).to.exist;
@@ -31,7 +33,7 @@ describe('fs.mkdir', function () {
   });
 
   it('should make a new directory', function (done) {
-    var fs = util.fs();
+    const fs = util.fs();
 
     fs.mkdir('/tmp', function (error) {
       expect(error).not.to.exist;
@@ -52,12 +54,12 @@ describe('fs.promises.mkdir', function () {
   afterEach(util.cleanup);
 
   it('should be a function', function () {
-    var fs = util.fs();
+    const fs = util.fs();
     expect(fs.promises.mkdir).to.be.a('function');
   });
 
   it('should return an error if part of the parent path does not exist', function () {
-    var fs = util.fs();
+    const fs = util.fs();
 
     return fs.promises.mkdir('/tmp/mydir')
       .catch(error => {
@@ -67,7 +69,7 @@ describe('fs.promises.mkdir', function () {
   });
 
   it('should return an error if the path already exists', function () {
-    var fs = util.fs();
+    const fs = util.fs();
 
     return fs.promises.mkdir('/')
       .catch(error =>{
@@ -77,7 +79,7 @@ describe('fs.promises.mkdir', function () {
   });
 
   it('should make a new directory', function () {
-    var fs = util.fs();
+    const fs = util.fs();
 
     return fs.promises.mkdir('/tmp')
       .then(() => fs.promises.stat('/tmp'))
@@ -88,7 +90,7 @@ describe('fs.promises.mkdir', function () {
   });
 
   it('should return a promise', function () {
-    var fs = util.fs();
+    const fs = util.fs();
     expect(fs.promises.mkdir('/tmp')).to.be.a('promise');
   });
 });


### PR DESCRIPTION
- [x] Invoked a `strict mode`
- [x] Refactored the code to use ~~let~~ and `const` instead of `var`
