### PR TITLE
fs.lstat should return a Stats object including mode

### DIFF
--- a/src/filesystem/implementation.js
+++ b/src/filesystem/implementation.js
@@ -917,6 +917,13 @@ function lstat_file(context, path, callback) {
     }
   }
 
+  function create_node(error, data) {
+    if(error) {
+      return callback(error);
+    }
+    Node.create(data, callback);
+  }
+
   function check_if_file_exists(error, result) {
     if(error) {
       callback(error);
@@ -925,7 +932,7 @@ function lstat_file(context, path, callback) {
       if(!directoryData.hasOwnProperty(name)) {
         callback(new Errors.ENOENT('a component of the path does not name an existing file', path));
       } else {
-        context.getObject(directoryData[name].id, callback);
+        context.getObject(directoryData[name].id, create_node);
       }
     }
   }

--- a/tests/spec/fs.lstat.spec.js
+++ b/tests/spec/fs.lstat.spec.js
@@ -46,6 +46,27 @@ describe('fs.lstat', function() {
       });
     });
   });
+
+  it('should have a mode (full node) when stat\'d with lstat', function(done) {
+    var fs = util.fs();
+
+    fs.writeFile('/file', 'data', function(error) {
+      if(error) throw error;
+
+      fs.symlink('/file', '/symlink', function(error) {
+        if(error) throw error;
+
+        fs.lstat('/symlink', function(error, stats) {
+          if(error) throw error;
+
+          // We should build and return a full node object, complete with
+          // calculated mode, which should be a SYMLINK and the default file permissions.
+          expect(stats.mode).to.equal(fs.constants.S_IFLNK | 0o644);
+          done();
+        });
+      });
+    });
+  });
 });
 
 describe('fs.promises.lstat', () => {

--- a/tests/spec/fs.symlink.spec.js
+++ b/tests/spec/fs.symlink.spec.js
@@ -46,6 +46,36 @@ describe('fs.symlink', function () {
     });
   });
 
+  it('should return the same node data for a file and symbolic link', function(done) {
+    var fs = util.fs();
+
+    fs.writeFile('/file', 'data', function(error) {
+      if(error) throw error;
+
+      fs.stat('/file', function(error, stats1) {
+        if(error) throw error;
+
+
+        fs.symlink('/file', '/symlink', function(error) {
+          if(error) throw error;
+
+          fs.stat('/symlink', function(error, stats2) {
+            if(error) throw error;
+
+            // The node names will differ, confirm and remove.
+            expect(stats1.name).to.equal('file');
+            delete stats1.name;
+            expect(stats2.name).to.equal('symlink');
+            delete stats2.name;
+
+            expect(stats2).to.deep.equal(stats1);
+            done();
+          });
+        });
+      });
+    });
+  });
+
   /** Tests for fsPromises API */
   describe('fsPromises.symlink', function () {
     it('should return an error if destination path does not exist', function () {


### PR DESCRIPTION
Working on my Linux-in-Browser shell again, and hit a bug where `fs.stat` is returning a proper `Stats` object with a `mode`, but `fs.lstat` is returning a raw database object.  This creates a proper `Node` object in `lstat`.  I've also added tests.