### PR TITLE
increase test timeout to 10 seconds from 5 seconds

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -12,7 +12,7 @@
   <script src="../node_modules/mocha/mocha.js"></script>
 
   <script>
-    mocha.setup('bdd').timeout(5000).slow(250);
+    mocha.setup('bdd').timeout(10000).slow(250);
 
     window.onload = function() {
       mocha.checkLeaks();


### PR DESCRIPTION
Increased test timeout to 10 seconds from 5 seconds due to exceeded timeouts on the Firefox tests as suggested by @humphd.

>     fs.watch
>     × "before each" hook: p for "should get a change event when writing a file beneath root dir with recursive=true"
>       Firefox 65.0.0 (Windows 10.0.0)
>     Timeout of 5000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
> 
>     × "after each" hook: h for "should get a change event when writing a file beneath root dir with recursive=true"
>       Firefox 65.0.0 (Windows 10.0.0)
>     Timeout of 5000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.