### PR TITLE
Fix #625 Add test for fs.readlink() when the path isn't a symbolic link

### DIFF
--- a/tests/spec/fs.readlink.spec.js
+++ b/tests/spec/fs.readlink.spec.js
@@ -3,42 +3,57 @@
 const util = require('../lib/test-utils.js');
 const expect = require('chai').expect;
 
-describe('fs.readlink', function() {
+describe('fs.readlink', function () {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
-  it('should be a function', function() {
+  it('should be a function', function () {
     const fs = util.fs();
     expect(fs.readlink).to.be.a('function');
   });
 
-  it('should return an error if part of the parent destination path does not exist', function(done) {
+  it('should return an error if part of the parent destination path does not exist', function (done) {
     const fs = util.fs();
 
-    fs.readlink('/tmp/mydir', function(error) {
+    fs.readlink('/tmp/mydir', function (error) {
       expect(error).to.exist;
       expect(error.code).to.equal('ENOENT');
       done();
     });
   });
 
-  it('should return an error if the path is not a symbolic link', function(done) {
+  it('should return an error if the path is not a symbolic link', function (done) {
     const fs = util.fs();
 
-    fs.readlink('/', function(error) {
+    fs.readlink('/', function (error) {
       expect(error).to.exist;
       expect(error.code).to.equal('ENOENT');
       done();
     });
   });
 
-  it('should return the contents of a symbolic link', function(done) {
+  it('should return an error if the path is not a symbolic link', function (done) {
     const fs = util.fs();
 
-    fs.symlink('/', '/myfile', function(error) {
-      if(error) throw error;
+    fs.mkdir('/tmp', function (error) {
+      if (error) throw error;
 
-      fs.readlink('/myfile', function(error, result) {
+      fs.readlink('/tmp', function (error) {
+        expect(error).to.exist;
+        expect(error.code).to.equal('EINVAL');
+        done();
+      });
+
+    });
+  });
+
+  it('should return the contents of a symbolic link', function (done) {
+    const fs = util.fs();
+
+    fs.symlink('/', '/myfile', function (error) {
+      if (error) throw error;
+
+      fs.readlink('/myfile', function (error, result) {
         expect(error).not.to.exist;
         expect(result).to.equal('/');
         done();
@@ -46,24 +61,24 @@ describe('fs.readlink', function() {
     });
   });
 
-  it('should allow relative paths, but resolve to the dstpath', function(done) {
+  it('should allow relative paths, but resolve to the dstpath', function (done) {
     const fs = util.fs();
     const contents = 'contents';
 
-    fs.mkdir('/dir', function(error) {
-      if(error) throw error;
+    fs.mkdir('/dir', function (error) {
+      if (error) throw error;
 
-      fs.writeFile('/file', contents, function(error) {
-        if(error) throw error;
+      fs.writeFile('/file', contents, function (error) {
+        if (error) throw error;
 
-        fs.symlink('../file', '/dir/symlink', function(error) {
-          if(error) throw error;
+        fs.symlink('../file', '/dir/symlink', function (error) {
+          if (error) throw error;
 
-          fs.readlink('/dir/symlink', function(error, result) {
+          fs.readlink('/dir/symlink', function (error, result) {
             expect(error).not.to.exist;
             expect(result).to.equal('../file');
 
-            fs.readFile('/dir/symlink', 'utf8', function(error, data) {
+            fs.readFile('/dir/symlink', 'utf8', function (error, data) {
               expect(error).not.to.exist;
               expect(data).to.equal(contents);
               done();


### PR DESCRIPTION
Fix for issue #625 

Added a test for fs.readlink() when the path isn't a symbolic link.