### PR TITLE
Issue 627

### DIFF
--- a/tests/spec/fs.readlink.spec.js
+++ b/tests/spec/fs.readlink.spec.js
@@ -3,42 +3,57 @@
 const util = require('../lib/test-utils.js');
 const expect = require('chai').expect;
 
-describe('fs.readlink', function() {
+describe('fs.readlink', function () {
   beforeEach(util.setup);
   afterEach(util.cleanup);
 
-  it('should be a function', function() {
+  it('should be a function', function () {
     const fs = util.fs();
     expect(fs.readlink).to.be.a('function');
   });
 
-  it('should return an error if part of the parent destination path does not exist', function(done) {
+  it('should return an error if part of the parent destination path does not exist', function (done) {
     const fs = util.fs();
 
-    fs.readlink('/tmp/mydir', function(error) {
+    fs.readlink('/tmp/mydir', function (error) {
       expect(error).to.exist;
       expect(error.code).to.equal('ENOENT');
       done();
     });
   });
 
-  it('should return an error if the path is not a symbolic link', function(done) {
+  it('should return an error if the path is not a symbolic link', function (done) {
     const fs = util.fs();
 
-    fs.readlink('/', function(error) {
+    fs.readlink('/', function (error) {
       expect(error).to.exist;
       expect(error.code).to.equal('ENOENT');
       done();
     });
   });
 
-  it('should return the contents of a symbolic link', function(done) {
+  it('should return an error if the path is not a symbolic link', function (done) {
     const fs = util.fs();
 
-    fs.symlink('/', '/myfile', function(error) {
-      if(error) throw error;
+    fs.mkdir('/tmp', function (error) {
+      if (error) throw error;
 
-      fs.readlink('/myfile', function(error, result) {
+      fs.readlink('/tmp', function (error) {
+        expect(error).to.exist;
+        expect(error.code).to.equal('EINVAL');
+        done();
+      });
+
+    });
+  });
+
+  it('should return the contents of a symbolic link', function (done) {
+    const fs = util.fs();
+
+    fs.symlink('/', '/myfile', function (error) {
+      if (error) throw error;
+
+      fs.readlink('/myfile', function (error, result) {
         expect(error).not.to.exist;
         expect(result).to.equal('/');
         done();
@@ -46,24 +61,24 @@ describe('fs.readlink', function() {
     });
   });
 
-  it('should allow relative paths, but resolve to the dstpath', function(done) {
+  it('should allow relative paths, but resolve to the dstpath', function (done) {
     const fs = util.fs();
     const contents = 'contents';
 
-    fs.mkdir('/dir', function(error) {
-      if(error) throw error;
+    fs.mkdir('/dir', function (error) {
+      if (error) throw error;
 
-      fs.writeFile('/file', contents, function(error) {
-        if(error) throw error;
+      fs.writeFile('/file', contents, function (error) {
+        if (error) throw error;
 
-        fs.symlink('../file', '/dir/symlink', function(error) {
-          if(error) throw error;
+        fs.symlink('../file', '/dir/symlink', function (error) {
+          if (error) throw error;
 
-          fs.readlink('/dir/symlink', function(error, result) {
+          fs.readlink('/dir/symlink', function (error, result) {
             expect(error).not.to.exist;
             expect(result).to.equal('../file');
 
-            fs.readFile('/dir/symlink', 'utf8', function(error, data) {
+            fs.readFile('/dir/symlink', 'utf8', function (error, data) {
               expect(error).not.to.exist;
               expect(data).to.equal(contents);
               done();

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -72,12 +72,12 @@ describe('fs.write', function() {
 
     fs.write('/myfile', buffer, 0, buffer.length, 0, function(error) {
       expect(error).to.exist;
-      expect(undefined).to.equal(undefined);
+      expect(error.code).to.equal('EBADF');
       done();
     });
   });
 
-  it('should fail to write a buffer whose length is too small', function(done) {
+  it('should fail when trying to write more bytes than are available in the buffer (length too long)', function(done) {
     const fs = util.fs();
     const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -86,7 +86,7 @@ describe('fs.write', function() {
 
       fs.write(fd, buffer, 0, (buffer.length + 10), 0, function(error) {
         expect(error).to.exist;
-        expect(undefined).to.equal(undefined);
+        expect(error.code).to.equal('EIO');
         fs.close(fd, done);
       });
     });

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -65,4 +65,23 @@ describe('fs.write', function() {
       });
     });
   });
+
+  it('should fail to write data to a file opened without the O_WRITE flag', function(done) {
+    const fs = util.fs();
+    const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    fs.mknod('/myfile', 'FILE', function(err) {
+      if (err) throw err;
+
+      fs.open('/myfile', 'r', function(error, fd) {
+        if(error) throw error;
+  
+        fs.write(fd, buffer, 0, buffer.length, 0, function(error) {
+          expect(error).to.exist;
+          expect(error.code).to.equal('EBADF');
+          done();
+        });
+      });
+    });
+  });
 });

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -66,6 +66,21 @@ describe('fs.write', function() {
     });
   });
 
+  it('should fail to write a buffer whose length is too small', function(done) {
+    const fs = util.fs();
+    const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    fs.open('/myfile', 'w', function(error, fd) {
+      if(error) throw error;
+
+      fs.write(fd, buffer, 0, (buffer.length + 10), 0, function(error) {
+        expect(error).to.exist;
+        expect(undefined).to.equal(undefined);
+        fs.close(fd, done);
+      });
+    });
+  });
+
   it('should fail to write data to a file opened without the O_WRITE flag', function(done) {
     const fs = util.fs();
     const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -66,6 +66,17 @@ describe('fs.write', function() {
     });
   });
 
+  it('should fail to write to a file that does not exist', function(done) {
+    const fs = util.fs();
+    const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    fs.write('/myfile', buffer, 0, buffer.length, 0, function(error) {
+      expect(error).to.exist;
+      expect(undefined).to.equal(undefined);
+      done();
+    });
+  });
+
   it('should fail to write a buffer whose length is too small', function(done) {
     const fs = util.fs();
     const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/tests/spec/fs.write.spec.js
+++ b/tests/spec/fs.write.spec.js
@@ -66,7 +66,7 @@ describe('fs.write', function() {
     });
   });
 
-  it('should fail to write to a file that does not exist', function(done) {
+  it('should fail if given a file path vs. an fd', function(done) {
     const fs = util.fs();
     const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
 


### PR DESCRIPTION
Fixes #627 by adding 3 tests to fs.write():

- Test that tries to use a non-existent fd
- Test that tries to open a file without the O_WRITE flag and then call fs.write
- Test that tries to write a buffer whose length is too small (buffer.length - offset < length)