### PR TITLE
docs: correct error in buffer shim documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ module.exports = {
   },
   plugins: [
     new webpack.ProvidePlugin({
-      Buffer: 'buffer',
+      Buffer: ['buffer', 'Buffer'],
     }),
   ]
 }


### PR DESCRIPTION
This PR corrects an error in the Buffer shim documentation. Using webpack.ProvidePlugin as previously documented would result in Buffer being globally defined as:
`{ __esModule: true, default: ..., Buffer: ... }`
The update to the documentation results in Buffer being resolved correctly by webpack.