### PR TITLE
Fix Issue #790

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,28 @@ your webpack config:
 
 ```javascript
 // webpack.config.js
-var filer = require('filer');
+var { FilerWebpackPlugin } = require('filer/webpack');
 
 module.exports = {
   plugins: [
-    new filer.FilerWebpackPlugin(),
+    new FilerWebpackPlugin(),
   ],
 }
 ```
 
+---
+**NOTE**
+
+Previously it was recommended to access the `FilerWebpackPlugin` class by importing the main filer module. This was depracated due the [this issue](https://github.com/filerjs/filer/issues/790). For anyone using ***filer version 1.3.1 or earlier***, please import the plugin class like this:
+
+```javascript
+var FilerWebpackPlugin = require('filer/src/webpack-plugin');
+```
+
+---
+
 You can then import the node.js [fs](http://nodejs.org/api/fs.html) and [path](http://nodejs.org/api/path.html)
-modules as normal and FilerWebpackPlugin will ensure that webpack will resolve references to these modules to
+modules as normal and `FilerWebpackPlugin` will ensure that webpack will resolve references to these modules to
 the appropriate filer shims. You will then be able to use these modules as normal (with the exception of the
 synchronous fs methods e.g. `mkdirSync()`).
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module.exports = {
 ---
 **NOTE**
 
-Previously it was recommended to access the `FilerWebpackPlugin` class by importing the main filer module. This was depracated due the [this issue](https://github.com/filerjs/filer/issues/790). For anyone using ***filer version 1.3.1 or earlier***, please import the plugin class like this:
+Previously it was recommended to access the `FilerWebpackPlugin` class by importing the main filer module. This was depracated due [this issue](https://github.com/filerjs/filer/issues/790). For anyone using ***filer version 1.3.1 or earlier***, please import the plugin class like this:
 
 ```javascript
 var FilerWebpackPlugin = require('filer/src/webpack-plugin');

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,15 @@ module.exports = Filer = {
   path: require('./path.js'),
   Errors: require('./errors.js'),
   Shell: require('./shell/shell.js'),
+  /**
+   * @deprecated Importing filer from your webpack config is not recommended.
+   * 
+   * The filer `FilerWebpackPlugin` class is exposed directly. 
+   * 
+   * ```
+   * const { FilerWebpackPlugin } = require('filer/webpack');
+   * ```
+   */
   FilerWebpackPlugin: require('./webpack-plugin'),
 };
 

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  FilerWebpackPlugin: require('../src/webpack-plugin'),
+};


### PR DESCRIPTION
This fixes issue #790 by exposing the `FilerWebpackPlugin` class through it's own import.

```javascript
var { FilerWebpackPlugin } = require('filer/webpack');
```

It also deprecates the following:

```javascript
var { FilerWebpackPlugin } = require('filer');
```

And updates the documentation in [README.md](https://github.com/filerjs/filer/blob/master/README.md) to reflect these changes.